### PR TITLE
Change group ID to be under org.zaproxy

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>com.crawljax</groupId>
+		<groupId>org.zaproxy.crawljax</groupId>
 		<artifactId>crawljax-parent-pom</artifactId>
 		<version>3.7-SNAPSHOT</version>
 	</parent>
@@ -40,7 +40,7 @@
 
 
 		<dependency>
-			<groupId>com.crawljax.plugins</groupId>
+			<groupId>org.zaproxy.crawljax.plugins</groupId>
 			<artifactId>crawloverview-plugin</artifactId>
 			<version>${project.version}</version>
 		</dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>com.crawljax</groupId>
+		<groupId>org.zaproxy.crawljax</groupId>
 		<artifactId>crawljax-parent-pom</artifactId>
 		<version>3.7-SNAPSHOT</version>
 	</parent>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>com.crawljax</groupId>
+		<groupId>org.zaproxy.crawljax</groupId>
 		<artifactId>crawljax-parent-pom</artifactId>
 		<version>3.7-SNAPSHOT</version>
 	</parent>
@@ -15,7 +15,7 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>com.crawljax.plugins</groupId>
+			<groupId>org.zaproxy.crawljax.plugins</groupId>
 			<artifactId>crawloverview-plugin</artifactId>
 			<version>${project.version}</version>
 		</dependency>

--- a/plugin-archetype/pom.xml
+++ b/plugin-archetype/pom.xml
@@ -2,12 +2,12 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
-		<groupId>com.crawljax</groupId>
+		<groupId>org.zaproxy.crawljax</groupId>
 		<artifactId>crawljax-parent-pom</artifactId>
 		<version>3.7-SNAPSHOT</version>
 	</parent>
 
-	<groupId>com.crawljax.plugins.archetypes</groupId>
+	<groupId>org.zaproxy.crawljax.plugins.archetypes</groupId>
 	<artifactId>crawljax-plugins-archetype</artifactId>
 
 	<packaging>jar</packaging>

--- a/plugin-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/plugin-archetype/src/main/resources/archetype-resources/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
-		<groupId>com.crawljax.plugins</groupId>
+		<groupId>org.zaproxy.crawljax.plugins</groupId>
 		<artifactId>crawljax-plugins-parent</artifactId>
 		<version>${project.version}</version>
 	</parent>

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -8,7 +8,7 @@ Parent POM
 Start out by adding the parent configuration to your pom:
 
     <parent>
-      <groupId>com.crawljax.plugins</groupId>
+      <groupId>org.zaproxy.crawljax.plugins</groupId>
       <artifactId>plugin</artifactId>
       <version>2.2</version>
     </parent>

--- a/plugins/crawloverview-plugin/README.md
+++ b/plugins/crawloverview-plugin/README.md
@@ -7,7 +7,7 @@ Maven
 -----
 
     <dependency>
-      <groupId>com.crawljax.plugins</groupId>
+      <groupId>org.zaproxy.crawljax.plugins</groupId>
       <artifactId>crawloverview</artifactId>
       <version>1.2</version>
     </dependency>

--- a/plugins/crawloverview-plugin/pom.xml
+++ b/plugins/crawloverview-plugin/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
-		<groupId>com.crawljax.plugins</groupId>
+		<groupId>org.zaproxy.crawljax.plugins</groupId>
 		<artifactId>crawljax-plugins-parent</artifactId>
 		<version>3.7-SNAPSHOT</version>
 	</parent>
@@ -63,12 +63,12 @@
 			<version>2.4.1</version>
 		</dependency>
 		<dependency>
-			<groupId>com.crawljax</groupId>
+			<groupId>org.zaproxy.crawljax</groupId>
 			<artifactId>crawljax-core</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>com.crawljax</groupId>
+			<groupId>org.zaproxy.crawljax</groupId>
 			<artifactId>crawljax-test-utils</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -2,12 +2,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>com.crawljax</groupId>
+		<groupId>org.zaproxy.crawljax</groupId>
 		<artifactId>crawljax-parent-pom</artifactId>
 		<version>3.7-SNAPSHOT</version>
 	</parent>
 
-	<groupId>com.crawljax.plugins</groupId>
+	<groupId>org.zaproxy.crawljax.plugins</groupId>
 	<artifactId>crawljax-plugins-parent</artifactId>
 	<packaging>pom</packaging>
 
@@ -32,7 +32,7 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>com.crawljax</groupId>
+			<groupId>org.zaproxy.crawljax</groupId>
 			<artifactId>crawljax-core</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>

--- a/plugins/test-plugin/pom.xml
+++ b/plugins/test-plugin/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>com.crawljax.plugins</groupId>
+		<groupId>org.zaproxy.crawljax.plugins</groupId>
 		<artifactId>crawljax-plugins-parent</artifactId>
 		<version>3.7-SNAPSHOT</version>
 	</parent>
@@ -12,7 +12,7 @@
 	<url>http://crawljax.com</url>
 	<dependencies>
 		<dependency>
-			<groupId>com.crawljax</groupId>
+			<groupId>org.zaproxy.crawljax</groupId>
 			<artifactId>crawljax-core</artifactId>
 			<version>${project.version}</version>
 		</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 		<version>9</version>
 	</parent>
 
-	<groupId>com.crawljax</groupId>
+	<groupId>org.zaproxy.crawljax</groupId>
 	<artifactId>crawljax-parent-pom</artifactId>
 	<version>3.7-SNAPSHOT</version>
 	<packaging>pom</packaging>
@@ -20,7 +20,6 @@
 		the various navigation paths and states within an Ajax
 		application.
 	</description>
-	<url>http://crawljax.com</url>
 	<inceptionYear>2012</inceptionYear>
 
 	<prerequisites>
@@ -40,31 +39,11 @@
 	</properties>
 
 	<scm>
-		<connection>scm:git:git@github.com:crawljax/crawljax.git</connection>
-		<developerConnection>scm:git:git@github.com:crawljax/crawljax.git</developerConnection>
-		<url>https://github.com/crawljax/crawljax</url>
+		<connection>scm:git:git@github.com:zaproxy/crawljax.git</connection>
+		<developerConnection>scm:git:git@github.com:zaproxy/crawljax.git</developerConnection>
+		<url>https://github.com/zaproxy/crawljax</url>
 		<tag>HEAD</tag>
 	</scm>
-
-	<issueManagement>
-		<system>GitHub</system>
-		<url>https://github.com/crawljax/crawljax/issues</url>
-	</issueManagement>
-
-	<ciManagement>
-		<system>Jenkins</system>
-		<url>http://jenkins.crawljax.com</url>
-	</ciManagement>
-
-	<mailingLists>
-		<mailingList>
-			<name>Crawljax Mailing List</name>
-			<subscribe>http://groups.google.com/group/crawljax/subscribe</subscribe>
-			<unsubscribe>crawljax+unsubscribe@googlegroups.com</unsubscribe>
-			<post>crawljax@googlegroups.com</post>
-			<archive>http://groups.google.com/group/crawljax</archive>
-		</mailingList>
-	</mailingLists>
 
 	<licenses>
 		<license>

--- a/test-utils/pom.xml
+++ b/test-utils/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>com.crawljax</groupId>
+		<groupId>org.zaproxy.crawljax</groupId>
 		<artifactId>crawljax-parent-pom</artifactId>
 		<version>3.7-SNAPSHOT</version>
 	</parent>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>com.crawljax</groupId>
+		<groupId>org.zaproxy.crawljax</groupId>
 		<artifactId>crawljax-parent-pom</artifactId>
 		<version>3.7-SNAPSHOT</version>
 	</parent>
@@ -19,17 +19,17 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>com.crawljax</groupId>
+			<groupId>org.zaproxy.crawljax</groupId>
 			<artifactId>crawljax-core</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>com.crawljax.plugins</groupId>
+			<groupId>org.zaproxy.crawljax.plugins</groupId>
 			<artifactId>crawloverview-plugin</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>com.crawljax.plugins</groupId>
+			<groupId>org.zaproxy.crawljax.plugins</groupId>
 			<artifactId>test-plugin</artifactId>
 			<version>${project.version}</version>
 		</dependency>


### PR DESCRIPTION
Change group ID of parent and modules to be under org.zaproxy (e.g.
org.zaproxy.crawljax) to make releases to Maven Central easier. While
all modules were changed only core is essential for ZAP (AJAX Spider
add-on), having all modules under the same group ID allows for easier
test of the changes done to core and hopefully make it easier to get
the changes integrated upstream.