### PR TITLE
Require geckodriver for Firefox tests

### DIFF
--- a/core/src/test/java/com/crawljax/core/largetests/LargeChromeTest.java
+++ b/core/src/test/java/com/crawljax/core/largetests/LargeChromeTest.java
@@ -1,44 +1,17 @@
 package com.crawljax.core.largetests;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assume.assumeThat;
-
-import java.io.IOException;
-
 import com.crawljax.browser.EmbeddedBrowser.BrowserType;
 import com.crawljax.core.configuration.BrowserConfiguration;
 import com.crawljax.test.BrowserTest;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
-import org.slf4j.LoggerFactory;
 
 @Category(BrowserTest.class)
 public class LargeChromeTest extends LargeTestBase {
 
-	private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(LargeChromeTest.class);
-
 	@BeforeClass
 	public static void setUpBeforeClass() throws Exception {
-		assumeThat(System.getProperty("webdriver.chrome.driver") != null
-		  || isOnClassPath(), is(true));
-	}
-
-	private static boolean isOnClassPath() throws IOException, InterruptedException {
-		try {
-			if (!System.getProperty("os.name").startsWith("Windows")) {
-				Process exec = Runtime.getRuntime().exec("which chromedriver");
-				boolean found = exec.waitFor() == 0;
-				LOG.info("Found chrom on the classpath = {}", found);
-				return found;
-			}
-			else {
-				return false;
-			}
-		}
-		catch (RuntimeException e) {
-			LOG.info("Could not determine if chrome is on the classpath: {}", e.getMessage());
-			return false;
-		}
+		assumeWebDriver("webdriver.chrome.driver", "chromedriver");
 	}
 
 	@Override

--- a/core/src/test/java/com/crawljax/core/largetests/LargeFirefoxTest.java
+++ b/core/src/test/java/com/crawljax/core/largetests/LargeFirefoxTest.java
@@ -1,5 +1,6 @@
 package com.crawljax.core.largetests;
 
+import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
 import com.crawljax.browser.EmbeddedBrowser.BrowserType;
@@ -8,6 +9,11 @@ import com.crawljax.test.BrowserTest;
 
 @Category(BrowserTest.class)
 public class LargeFirefoxTest extends LargeTestBase {
+
+	@BeforeClass
+	public static void setUpBeforeClass() throws Exception {
+		assumeWebDriver("webdriver.gecko.driver", "geckodriver");
+	}
 
 	@Override
 	BrowserConfiguration getBrowserConfiguration() {

--- a/core/src/test/java/com/crawljax/core/largetests/LargeTestBase.java
+++ b/core/src/test/java/com/crawljax/core/largetests/LargeTestBase.java
@@ -3,11 +3,14 @@ package com.crawljax.core.largetests;
 import static com.crawljax.browser.matchers.StateFlowGraphMatchers.stateWithDomSubstring;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeThat;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -110,6 +113,29 @@ public abstract class LargeTestBase {
 
 	@Rule
 	public final Timeout timeout = new Timeout((int) TimeUnit.MINUTES.toMillis(15));
+
+	protected static void assumeWebDriver(String systemProperty, String binaryName) throws Exception {
+		assumeThat(System.getProperty(systemProperty) != null
+		  || isOnClassPath(binaryName), is(true));
+	}
+
+	private static boolean isOnClassPath(String binaryName) throws IOException, InterruptedException {
+		try {
+			if (!System.getProperty("os.name").startsWith("Windows")) {
+				Process exec = Runtime.getRuntime().exec("which " + binaryName);
+				boolean found = exec.waitFor() == 0;
+				LOG.info("Found {} on the classpath = {}", binaryName, found);
+				return found;
+			}
+			else {
+				return false;
+			}
+		}
+		catch (RuntimeException e) {
+			LOG.info("Could not determine if {} is on the classpath: {}", binaryName, e.getMessage());
+			return false;
+		}
+	}
 
 	@Before
 	public void setup() throws Exception {


### PR DESCRIPTION
Change LargeFirefoxTest to require the geckodriver to run the tests,
needed for "newer" Firefox versions (48+).
Refactor the code that checks the presence of the WebDriver (move to
base class LargeTestBase), now used by LargeChromeTest and
LargeFirefoxTest.