### PR TITLE
Ensure large tests are always set as finished

### DIFF
--- a/core/src/test/java/com/crawljax/core/largetests/LargeTestBase.java
+++ b/core/src/test/java/com/crawljax/core/largetests/LargeTestBase.java
@@ -115,10 +115,13 @@ public abstract class LargeTestBase {
 	public void setup() throws Exception {
 		if (!HAS_RUN.get()) {
 			HAS_RUN.set(true);
-			CrawljaxRunner crawljax = null;
-			crawljax = new CrawljaxRunner(getCrawljaxConfiguration());
-			session = crawljax.call();
-			HAS_FINISHED.set(true);
+			try {
+				CrawljaxRunner crawljax = null;
+				crawljax = new CrawljaxRunner(getCrawljaxConfiguration());
+				session = crawljax.call();
+			} finally {
+				HAS_FINISHED.set(true);
+			}
 		}
 		else {
 			while (!HAS_FINISHED.get()) {


### PR DESCRIPTION
Change LargeTestBase.setup() to set that the tests have finished in a
finally block, to ensure that the tests are always set as finished even
in case of exceptions (e.g. incompatible libraries), thus preventing the
tests from hanging/sleeping.