### PR TITLE
Update Selenium to 3.4.0

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -135,17 +135,7 @@
 		<dependency>
   			<groupId>com.codeborne</groupId>
   			<artifactId>phantomjsdriver</artifactId>
-  			<version>1.2.1</version>
-			<exclusions>
-				<exclusion>
-					<artifactId>servlet-api-2.5</artifactId>
-					<groupId>org.mortbay.jetty</groupId>
-				</exclusion>
-				<exclusion>
-					<artifactId>selenium-htmlunit-driver</artifactId>
-					<groupId>org.seleniumhq.selenium</groupId>
-				</exclusion>
-			</exclusions>
+  			<version>1.4.3</version>
 		</dependency>
 
 	</dependencies>

--- a/core/src/main/java/com/crawljax/condition/ConditionType.java
+++ b/core/src/main/java/com/crawljax/condition/ConditionType.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import javax.annotation.concurrent.Immutable;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 
@@ -93,7 +94,7 @@ public abstract class ConditionType {
 
 	@Override
 	public String toString() {
-		return Objects.toStringHelper(this)
+		return MoreObjects.toStringHelper(this)
 		        .add("preConditions", preConditions)
 		        .add("description", description)
 		        .add("condition", condition)

--- a/core/src/main/java/com/crawljax/condition/ConditionTypeChecker.java
+++ b/core/src/main/java/com/crawljax/condition/ConditionTypeChecker.java
@@ -6,6 +6,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.crawljax.browser.EmbeddedBrowser;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -81,7 +82,7 @@ public class ConditionTypeChecker<T extends ConditionType> {
 
 	@Override
 	public String toString() {
-		return Objects.toStringHelper(this)
+		return MoreObjects.toStringHelper(this)
 		        .add("invariants", invariants)
 		        .toString();
 	}

--- a/core/src/main/java/com/crawljax/condition/CountCondition.java
+++ b/core/src/main/java/com/crawljax/condition/CountCondition.java
@@ -5,6 +5,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import net.jcip.annotations.ThreadSafe;
 
 import com.crawljax.browser.EmbeddedBrowser;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
 /**
@@ -45,7 +46,7 @@ public class CountCondition implements Condition {
 
 	@Override
 	public String toString() {
-		return Objects.toStringHelper(this)
+		return MoreObjects.toStringHelper(this)
 		        .add("condition", condition)
 		        .add("maxCount", maxCount)
 		        .toString();

--- a/core/src/main/java/com/crawljax/condition/JavaScriptCondition.java
+++ b/core/src/main/java/com/crawljax/condition/JavaScriptCondition.java
@@ -4,6 +4,7 @@ import net.jcip.annotations.Immutable;
 
 import com.crawljax.browser.EmbeddedBrowser;
 import com.crawljax.core.CrawljaxException;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
 /**
@@ -66,7 +67,7 @@ public class JavaScriptCondition implements Condition {
 
 	@Override
 	public String toString() {
-		return Objects.toStringHelper(this)
+		return MoreObjects.toStringHelper(this)
 		        .add("expression", expression)
 		        .toString();
 	}

--- a/core/src/main/java/com/crawljax/condition/Logic.java
+++ b/core/src/main/java/com/crawljax/condition/Logic.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import net.jcip.annotations.Immutable;
 
 import com.crawljax.browser.EmbeddedBrowser;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
 /**
@@ -66,7 +67,7 @@ public final class Logic {
 
 		@Override
 		public String toString() {
-			return Objects.toStringHelper(this)
+			return MoreObjects.toStringHelper(this)
 			        .add("condition", condition)
 			        .toString();
 		}
@@ -105,7 +106,7 @@ public final class Logic {
 
 		@Override
 		public String toString() {
-			return Objects.toStringHelper(this)
+			return MoreObjects.toStringHelper(this)
 			        .add("condition", Arrays.deepToString(conditions))
 			        .toString();
 		}
@@ -145,7 +146,7 @@ public final class Logic {
 
 		@Override
 		public String toString() {
-			return Objects.toStringHelper(this)
+			return MoreObjects.toStringHelper(this)
 			        .add("condition", Arrays.deepToString(conditions))
 			        .toString();
 		}

--- a/core/src/main/java/com/crawljax/condition/NotRegexCondition.java
+++ b/core/src/main/java/com/crawljax/condition/NotRegexCondition.java
@@ -3,6 +3,7 @@ package com.crawljax.condition;
 import net.jcip.annotations.Immutable;
 
 import com.crawljax.browser.EmbeddedBrowser;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
 /**
@@ -44,7 +45,7 @@ public class NotRegexCondition implements Condition {
 
 	@Override
 	public String toString() {
-		return Objects.toStringHelper(this)
+		return MoreObjects.toStringHelper(this)
 		        .add("regexCondition", regexCondition)
 		        .toString();
 	}

--- a/core/src/main/java/com/crawljax/condition/NotUrlCondition.java
+++ b/core/src/main/java/com/crawljax/condition/NotUrlCondition.java
@@ -3,6 +3,7 @@ package com.crawljax.condition;
 import net.jcip.annotations.Immutable;
 
 import com.crawljax.browser.EmbeddedBrowser;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
 /**
@@ -45,7 +46,7 @@ public class NotUrlCondition implements Condition {
 
 	@Override
 	public String toString() {
-		return Objects.toStringHelper(this)
+		return MoreObjects.toStringHelper(this)
 		        .add("urlCondition", urlCondition)
 		        .toString();
 	}

--- a/core/src/main/java/com/crawljax/condition/NotVisibleCondition.java
+++ b/core/src/main/java/com/crawljax/condition/NotVisibleCondition.java
@@ -4,6 +4,7 @@ import net.jcip.annotations.Immutable;
 
 import com.crawljax.browser.EmbeddedBrowser;
 import com.crawljax.core.state.Identification;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
 /**
@@ -45,7 +46,7 @@ public class NotVisibleCondition implements Condition {
 
 	@Override
 	public String toString() {
-		return Objects.toStringHelper(this)
+		return MoreObjects.toStringHelper(this)
 		        .add("visibleCondition", visibleCondition)
 		        .toString();
 	}

--- a/core/src/main/java/com/crawljax/condition/NotXPathCondition.java
+++ b/core/src/main/java/com/crawljax/condition/NotXPathCondition.java
@@ -3,6 +3,7 @@ package com.crawljax.condition;
 import net.jcip.annotations.Immutable;
 
 import com.crawljax.browser.EmbeddedBrowser;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
 /**
@@ -44,7 +45,7 @@ public class NotXPathCondition implements Condition {
 
 	@Override
 	public String toString() {
-		return Objects.toStringHelper(this)
+		return MoreObjects.toStringHelper(this)
 		        .add("xpathCondition", xpathCondition)
 		        .toString();
 	}

--- a/core/src/main/java/com/crawljax/condition/RegexCondition.java
+++ b/core/src/main/java/com/crawljax/condition/RegexCondition.java
@@ -8,6 +8,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.crawljax.browser.EmbeddedBrowser;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
 /**
@@ -56,7 +57,7 @@ public class RegexCondition implements Condition {
 
 	@Override
 	public String toString() {
-		return Objects.toStringHelper(this)
+		return MoreObjects.toStringHelper(this)
 		        .add("expression", expression.toString())
 		        .add("pattern", pattern.toString())
 		        .toString();

--- a/core/src/main/java/com/crawljax/condition/UrlCondition.java
+++ b/core/src/main/java/com/crawljax/condition/UrlCondition.java
@@ -3,6 +3,7 @@ package com.crawljax.condition;
 import net.jcip.annotations.Immutable;
 
 import com.crawljax.browser.EmbeddedBrowser;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
 /**
@@ -44,7 +45,7 @@ public class UrlCondition implements Condition {
 
 	@Override
 	public String toString() {
-		return Objects.toStringHelper(this)
+		return MoreObjects.toStringHelper(this)
 		        .add("url", url)
 		        .toString();
 	}

--- a/core/src/main/java/com/crawljax/condition/VisibleCondition.java
+++ b/core/src/main/java/com/crawljax/condition/VisibleCondition.java
@@ -4,6 +4,7 @@ import net.jcip.annotations.Immutable;
 
 import com.crawljax.browser.EmbeddedBrowser;
 import com.crawljax.core.state.Identification;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
 /**
@@ -29,7 +30,7 @@ public class VisibleCondition implements Condition {
 
 	@Override
 	public String toString() {
-		return Objects.toStringHelper(this)
+		return MoreObjects.toStringHelper(this)
 		        .add("identification", identification)
 		        .toString();
 	}

--- a/core/src/main/java/com/crawljax/condition/XPathCondition.java
+++ b/core/src/main/java/com/crawljax/condition/XPathCondition.java
@@ -12,6 +12,7 @@ import org.w3c.dom.NodeList;
 import com.crawljax.browser.EmbeddedBrowser;
 import com.crawljax.util.DomUtils;
 import com.crawljax.util.XPathHelper;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
 /**
@@ -66,7 +67,7 @@ public class XPathCondition implements Condition {
 
 	@Override
 	public String toString() {
-		return Objects.toStringHelper(this)
+		return MoreObjects.toStringHelper(this)
 		        .add("expression", expression)
 		        .toString();
 	}

--- a/core/src/main/java/com/crawljax/condition/invariant/Invariant.java
+++ b/core/src/main/java/com/crawljax/condition/invariant/Invariant.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 import com.crawljax.condition.Condition;
 import com.crawljax.condition.ConditionType;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 
 /**
  * An Invariant is an condition which should always hold when its preconditions are satisfied.
@@ -55,7 +55,7 @@ public class Invariant extends ConditionType {
 
 	@Override
 	public String toString() {
-		return Objects.toStringHelper(this)
+		return MoreObjects.toStringHelper(this)
 		        .add("description", getDescription())
 		        .add("condition", getInvariantCondition())
 		        .toString();

--- a/core/src/main/java/com/crawljax/core/CandidateCrawlAction.java
+++ b/core/src/main/java/com/crawljax/core/CandidateCrawlAction.java
@@ -1,7 +1,7 @@
 package com.crawljax.core;
 
 import com.crawljax.core.state.Eventable.EventType;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 
 /**
  * This class corresponds the combination of a CandidateElement and a single
@@ -44,7 +44,7 @@ public class CandidateCrawlAction {
 
 	@Override
 	public String toString() {
-		return Objects.toStringHelper(this)
+		return MoreObjects.toStringHelper(this)
 				.add("candidateElement", candidateElement)
 				.add("eventType", eventType).toString();
 	}

--- a/core/src/main/java/com/crawljax/core/CandidateElement.java
+++ b/core/src/main/java/com/crawljax/core/CandidateElement.java
@@ -10,6 +10,7 @@ import com.crawljax.core.state.Eventable;
 import com.crawljax.core.state.Identification;
 import com.crawljax.forms.FormInput;
 import com.crawljax.util.DomUtils;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -154,7 +155,7 @@ public class CandidateElement {
 
 	@Override
 	public String toString() {
-		return Objects.toStringHelper(this)
+		return MoreObjects.toStringHelper(this)
 		        .add("identification", identification)
 		        .add("element", element)
 		        .add("formInputs", formInputs)

--- a/core/src/main/java/com/crawljax/core/configuration/BrowserConfiguration.java
+++ b/core/src/main/java/com/crawljax/core/configuration/BrowserConfiguration.java
@@ -8,6 +8,7 @@ import javax.inject.Provider;
 import com.crawljax.browser.EmbeddedBrowser;
 import com.crawljax.browser.EmbeddedBrowser.BrowserType;
 import com.crawljax.browser.WebDriverBrowserBuilder;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 
@@ -124,7 +125,7 @@ public class BrowserConfiguration {
 
 	@Override
 	public String toString() {
-		return Objects.toStringHelper(this)
+		return MoreObjects.toStringHelper(this)
 		        .add("browsertype", browsertype)
 		        .add("numberOfBrowsers", numberOfBrowsers)
 		        .add("browserBuilder", browserBuilder)

--- a/core/src/main/java/com/crawljax/core/configuration/CrawlElement.java
+++ b/core/src/main/java/com/crawljax/core/configuration/CrawlElement.java
@@ -6,6 +6,7 @@ import java.util.List;
 import com.crawljax.condition.Condition;
 import com.crawljax.condition.eventablecondition.EventableCondition;
 import com.crawljax.core.state.Eventable.EventType;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -169,7 +170,7 @@ public final class CrawlElement {
 
 	@Override
 	public String toString() {
-		return Objects.toStringHelper(this).add("tagName", tagName)
+		return MoreObjects.toStringHelper(this).add("tagName", tagName)
 				.add("conditions", conditions).add("id", id)
 				.add("eventType", eventType)
 				.add("inputFieldIds", inputFieldIds)

--- a/core/src/main/java/com/crawljax/core/configuration/CrawlRules.java
+++ b/core/src/main/java/com/crawljax/core/configuration/CrawlRules.java
@@ -14,6 +14,7 @@ import com.crawljax.core.configuration.PreCrawlConfiguration.PreCrawlConfigurati
 import com.crawljax.core.state.Eventable.EventType;
 import com.crawljax.oraclecomparator.OracleComparator;
 import com.crawljax.oraclecomparator.comparators.SimpleComparator;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -461,7 +462,7 @@ public class CrawlRules {
 
 	@Override
 	public String toString() {
-		return Objects.toStringHelper(this)
+		return MoreObjects.toStringHelper(this)
 		        .add("DEFAULT_WAIT_AFTER_RELOAD", DEFAULT_WAIT_AFTER_RELOAD)
 		        .add("DEFAULT_WAIT_AFTER_EVENT", DEFAULT_WAIT_AFTER_EVENT)
 		        .add("crawlEvents", crawlEvents)

--- a/core/src/main/java/com/crawljax/core/configuration/CrawljaxConfiguration.java
+++ b/core/src/main/java/com/crawljax/core/configuration/CrawljaxConfiguration.java
@@ -14,6 +14,7 @@ import com.crawljax.core.CrawljaxException;
 import com.crawljax.core.configuration.CrawlRules.CrawlRulesBuilder;
 import com.crawljax.core.plugin.Plugin;
 import com.crawljax.core.state.StateVertexFactory;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -318,7 +319,7 @@ public class CrawljaxConfiguration {
 
 	@Override
 	public String toString() {
-		return Objects.toStringHelper(this).add("url", url).add("browserConfig", browserConfig)
+		return MoreObjects.toStringHelper(this).add("url", url).add("browserConfig", browserConfig)
 		        .add("plugins", plugins).add("proxyConfiguration", proxyConfiguration)
 		        .add("crawlRules", crawlRules).add("maximumStates", maximumStates)
 		        .add("maximumRuntime", maximumRuntime).add("maximumDepth", maximumDepth)

--- a/core/src/main/java/com/crawljax/core/configuration/PreCrawlConfiguration.java
+++ b/core/src/main/java/com/crawljax/core/configuration/PreCrawlConfiguration.java
@@ -4,6 +4,7 @@ import org.apache.commons.lang3.tuple.Pair;
 
 import com.crawljax.condition.browserwaiter.WaitCondition;
 import com.crawljax.condition.crawlcondition.CrawlCondition;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedSet;
@@ -107,7 +108,7 @@ public class PreCrawlConfiguration {
 
 	@Override
 	public String toString() {
-		return Objects.toStringHelper(this)
+		return MoreObjects.toStringHelper(this)
 		        .add("waitConditions", waitConditions)
 		        .add("crawlConditions", crawlConditions)
 		        .add("includedElements", includedElements)

--- a/core/src/main/java/com/crawljax/core/plugin/Plugins.java
+++ b/core/src/main/java/com/crawljax/core/plugin/Plugins.java
@@ -23,6 +23,7 @@ import com.crawljax.core.configuration.CrawljaxConfiguration;
 import com.crawljax.core.state.Eventable;
 import com.crawljax.core.state.StateVertex;
 import com.crawljax.metrics.MetricsModule;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -421,7 +422,7 @@ public class Plugins {
 
 	@Override
 	public String toString() {
-		return Objects.toStringHelper(this).add("plugins", plugins).toString();
+		return MoreObjects.toStringHelper(this).add("plugins", plugins).toString();
 	}
 
 	/**

--- a/core/src/main/java/com/crawljax/core/state/Element.java
+++ b/core/src/main/java/com/crawljax/core/state/Element.java
@@ -8,6 +8,7 @@ import javax.annotation.concurrent.Immutable;
 import org.w3c.dom.Node;
 
 import com.crawljax.util.DomUtils;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
@@ -136,7 +137,7 @@ public class Element implements Serializable {
 
 	@Override
 	public String toString() {
-		return Objects.toStringHelper(this)
+		return MoreObjects.toStringHelper(this)
 		        .add("node", node)
 		        .add("tag", tag)
 		        .add("text", text)

--- a/core/src/main/java/com/crawljax/core/state/Eventable.java
+++ b/core/src/main/java/com/crawljax/core/state/Eventable.java
@@ -15,6 +15,7 @@ import com.crawljax.core.CrawljaxException;
 import com.crawljax.forms.FormInput;
 import com.crawljax.util.XPathHelper;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
 /**
@@ -233,7 +234,7 @@ public class Eventable extends DefaultEdge implements Serializable {
 
 	@Override
 	public String toString() {
-		return Objects.toStringHelper(this)
+		return MoreObjects.toStringHelper(this)
 		        .add("eventType", eventType)
 		        .add("identification", identification)
 		        .add("element", element)

--- a/core/src/main/java/com/crawljax/core/state/StateVertexImpl.java
+++ b/core/src/main/java/com/crawljax/core/state/StateVertexImpl.java
@@ -6,6 +6,7 @@ import java.util.LinkedList;
 import com.crawljax.core.CandidateElement;
 import com.crawljax.util.DomUtils;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import org.w3c.dom.Document;
@@ -96,7 +97,7 @@ public class StateVertexImpl implements StateVertex {
 
 	@Override
 	public String toString() {
-		return Objects.toStringHelper(this)
+		return MoreObjects.toStringHelper(this)
 		        .add("id", id)
 		        .add("name", name)
 		        .toString();

--- a/plugins/crawloverview-plugin/src/main/java/com/crawljax/plugins/crawloverview/model/CandidateElementPosition.java
+++ b/plugins/crawloverview-plugin/src/main/java/com/crawljax/plugins/crawloverview/model/CandidateElementPosition.java
@@ -8,6 +8,7 @@ import org.openqa.selenium.Point;
 import com.crawljax.core.CandidateElement;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
 /**
@@ -77,7 +78,7 @@ public class CandidateElementPosition {
 
 	@Override
 	public String toString() {
-		return Objects.toStringHelper(this)
+		return MoreObjects.toStringHelper(this)
 		        .add("top", top)
 		        .add("left", left)
 		        .add("xpath", xpath)

--- a/plugins/crawloverview-plugin/src/main/java/com/crawljax/plugins/crawloverview/model/OutPutModel.java
+++ b/plugins/crawloverview-plugin/src/main/java/com/crawljax/plugins/crawloverview/model/OutPutModel.java
@@ -5,6 +5,7 @@ import javax.annotation.concurrent.Immutable;
 import com.crawljax.core.ExitNotifier.ExitStatus;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -70,7 +71,7 @@ public final class OutPutModel {
 
 	@Override
 	public String toString() {
-		return Objects.toStringHelper(this).add("exitStatus", exitStatus)
+		return MoreObjects.toStringHelper(this).add("exitStatus", exitStatus)
 		        .add("states", states).add("edges", edges)
 		        .add("statistics", statistics).toString();
 	}

--- a/plugins/crawloverview-plugin/src/main/java/com/crawljax/plugins/crawloverview/model/State.java
+++ b/plugins/crawloverview-plugin/src/main/java/com/crawljax/plugins/crawloverview/model/State.java
@@ -6,6 +6,7 @@ import com.crawljax.core.state.StateVertex;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 
@@ -104,7 +105,7 @@ public class State {
 
 	@Override
 	public String toString() {
-		return Objects.toStringHelper(this).add("name", name).add("id", id)
+		return MoreObjects.toStringHelper(this).add("name", name).add("id", id)
 		        .add("url", url).add("candidateElements", candidateElements)
 		        .add("fanIn", fanIn).add("fanOut", fanOut)
 		        .add("failedEvents", failedEvents).toString();

--- a/plugins/crawloverview-plugin/src/main/java/com/crawljax/plugins/crawloverview/model/StateCounter.java
+++ b/plugins/crawloverview-plugin/src/main/java/com/crawljax/plugins/crawloverview/model/StateCounter.java
@@ -2,6 +2,7 @@ package com.crawljax.plugins.crawloverview.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
 public class StateCounter {
@@ -25,7 +26,7 @@ public class StateCounter {
 
 	@Override
 	public String toString() {
-		return Objects.toStringHelper(this)
+		return MoreObjects.toStringHelper(this)
 		        .add("id", id)
 		        .add("count", count)
 		        .toString();

--- a/plugins/crawloverview-plugin/src/main/java/com/crawljax/plugins/crawloverview/model/StateStatistics.java
+++ b/plugins/crawloverview-plugin/src/main/java/com/crawljax/plugins/crawloverview/model/StateStatistics.java
@@ -6,6 +6,7 @@ import javax.annotation.concurrent.Immutable;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSetMultimap;
 
@@ -112,7 +113,7 @@ public class StateStatistics {
 
 	@Override
 	public String toString() {
-		return Objects.toStringHelper(this)
+		return MoreObjects.toStringHelper(this)
 		        .add("leastFanOut", leastFanOut)
 		        .add("leastFanIn", leastFanIn)
 		        .add("mostFanOut", mostFanOut)

--- a/plugins/crawloverview-plugin/src/main/java/com/crawljax/plugins/crawloverview/model/Statistics.java
+++ b/plugins/crawloverview-plugin/src/main/java/com/crawljax/plugins/crawloverview/model/Statistics.java
@@ -11,6 +11,7 @@ import com.crawljax.core.CrawlSession;
 import com.crawljax.core.state.StateFlowGraph;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
 @Immutable
@@ -109,7 +110,7 @@ public class Statistics {
 
 	@Override
 	public String toString() {
-		return Objects.toStringHelper(this)
+		return MoreObjects.toStringHelper(this)
 		        .add("duration", duration)
 		        .add("failedEvents", failedEvents)
 		        .add("crawlPaths", crawlPaths)

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,9 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<slf4j.version>1.7.7</slf4j.version>
 		<logback.version>1.1.2</logback.version>
-		<selenium.version>[2.48.0,)</selenium.version>
+		<selenium.version>3.4.0</selenium.version>
+		<!-- Guava version used by Crawljax needs to be compatible with the one used by Selenium, otherwise JAR hell. -->
+		<guava.version>21.0</guava.version>
 		<jetty.version>9.3.0.M1</jetty.version>
 		<metrics.version>3.0.2</metrics.version>
 	</properties>
@@ -88,7 +90,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>18.0</version>
+			<version>${guava.version}</version>
 		</dependency>
 
 		<!-- Logging -->

--- a/test-utils/pom.xml
+++ b/test-utils/pom.xml
@@ -31,6 +31,11 @@
 			<version>${project.version}</version>
 			<type>test-jar</type>
 		</dependency>
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.5</version>
+		</dependency>
 
 		<dependency>
 			<groupId>junit</groupId>


### PR DESCRIPTION
Update Selenium to 3.4.0 (exactly, to avoid issues with its
dependencies).
Update Guava to the same version as used by Selenium (they were no
longer binary compatible) and update code accordingly.
Update phantomjsdriver to 1.4.3, already depending on Selenium 3.4.0,
also, remove exclusions no longer needed (phantomjsdriver is no longer
depending on selenium-java but selenium-api, which no longer includes
the excluded dependencies).
Add commons-io as dependency of test-utils (was a transitive dependency
phantomjsdriver > selenium-java > commons-io).

Related to zaproxy/zaproxy#3509 - Update Selenium library to version 3.x