### PR TITLE
Allow to specify a crawl scope

### DIFF
--- a/core/src/main/java/com/crawljax/core/CrawlerLeftDomainException.java
+++ b/core/src/main/java/com/crawljax/core/CrawlerLeftDomainException.java
@@ -1,13 +1,13 @@
 package com.crawljax.core;
 
 /**
- * Is thrown when the browser leaves the domain while crawling.
+ * Is thrown when the browser leaves the domain/scope while crawling.
  */
 @SuppressWarnings("serial")
 public class CrawlerLeftDomainException extends CrawljaxException {
 
 	public CrawlerLeftDomainException(String currentUrl) {
-		super("Somehow we left the domain to " + currentUrl);
+		super("Somehow we left the domain/scope to " + currentUrl);
 	}
 
 }

--- a/core/src/main/java/com/crawljax/core/configuration/CrawlScope.java
+++ b/core/src/main/java/com/crawljax/core/configuration/CrawlScope.java
@@ -1,0 +1,23 @@
+package com.crawljax.core.configuration;
+
+/**
+ * The crawl scope allows to check if a URL is or not in scope.
+ * <p>
+ * URLs in scope are crawled during the crawling process.
+ * 
+ * @since 3.7
+ */
+@FunctionalInterface
+public interface CrawlScope {
+
+	/**
+	 * Tells whether or not the given URL is in scope.
+	 * <p>
+	 * Called during the crawl process, to know if the crawling process should crawl or backtrack.
+	 * 
+	 * @param url
+	 *            the URL to check if it's in scope.
+	 * @return {@code true} if the given URL is in scope, {@code false} otherwise.
+	 */
+	boolean isInScope(String url);
+}

--- a/core/src/main/java/com/crawljax/core/configuration/CrawljaxConfiguration.java
+++ b/core/src/main/java/com/crawljax/core/configuration/CrawljaxConfiguration.java
@@ -38,6 +38,21 @@ public class CrawljaxConfiguration {
 		}
 
 		/**
+		 * Sets the crawl scope.
+		 * <p>
+		 * If {@code null}, then a {@link DefaultCrawlScope} is used.
+		 * 
+		 * @param crawlScope
+		 *            the crawl scope
+		 * @return this {@code CrawljaxConfigurationBuilder} for method chaining.
+		 * @since 3.7
+		 */
+		public CrawljaxConfigurationBuilder setCrawlScope(CrawlScope crawlScope) {
+			config.crawlScope = crawlScope;
+			return this;
+		}
+
+		/**
 		 * If the website uses <a
 		 * href="http://en.wikipedia.org/wiki/Basic_access_authentication">Basic auth</a> you can
 		 * set the username and password here.
@@ -208,6 +223,11 @@ public class CrawljaxConfiguration {
 		public CrawljaxConfiguration build() {
 			config.plugins = pluginBuilder.build();
 			config.crawlRules = crawlRules.build();
+
+			if (config.crawlScope == null) {
+				config.crawlScope = new DefaultCrawlScope(config.getUrl());
+			}
+
 			return config;
 		}
 
@@ -235,6 +255,8 @@ public class CrawljaxConfiguration {
 	private URI url;
 	private URI basicAuthUrl;
 
+	private CrawlScope crawlScope;
+
 	private BrowserConfiguration browserConfig = new BrowserConfiguration(BrowserType.FIREFOX);
 	private ImmutableList<Plugin> plugins;
 	private ProxyConfiguration proxyConfiguration = ProxyConfiguration.noProxy();
@@ -257,6 +279,10 @@ public class CrawljaxConfiguration {
 
 	public URI getBasicAuthUrl() {
 		return basicAuthUrl;
+	}
+
+	public CrawlScope getCrawlScope() {
+		return crawlScope;
 	}
 
 	public BrowserConfiguration getBrowserConfig() {
@@ -297,8 +323,8 @@ public class CrawljaxConfiguration {
 
 	@Override
 	public int hashCode() {
-		return Objects.hashCode(url, browserConfig, plugins, proxyConfiguration, crawlRules,
-		        maximumStates, maximumRuntime, maximumDepth);
+		return Objects.hashCode(url, crawlScope, browserConfig, plugins, proxyConfiguration,
+		        crawlRules, maximumStates, maximumRuntime, maximumDepth);
 	}
 
 	@Override
@@ -310,6 +336,7 @@ public class CrawljaxConfiguration {
 			        && Objects.equal(this.plugins, that.plugins)
 			        && Objects.equal(this.proxyConfiguration, that.proxyConfiguration)
 			        && Objects.equal(this.crawlRules, that.crawlRules)
+			        && Objects.equal(this.crawlScope, that.crawlScope)
 			        && Objects.equal(this.maximumStates, that.maximumStates)
 			        && Objects.equal(this.maximumRuntime, that.maximumRuntime)
 			        && Objects.equal(this.maximumDepth, that.maximumDepth);
@@ -319,7 +346,8 @@ public class CrawljaxConfiguration {
 
 	@Override
 	public String toString() {
-		return MoreObjects.toStringHelper(this).add("url", url).add("browserConfig", browserConfig)
+		return MoreObjects.toStringHelper(this).add("url", url)
+		        .add("crawlScope", crawlScope).add("browserConfig", browserConfig)
 		        .add("plugins", plugins).add("proxyConfiguration", proxyConfiguration)
 		        .add("crawlRules", crawlRules).add("maximumStates", maximumStates)
 		        .add("maximumRuntime", maximumRuntime).add("maximumDepth", maximumDepth)

--- a/core/src/main/java/com/crawljax/core/configuration/DefaultCrawlScope.java
+++ b/core/src/main/java/com/crawljax/core/configuration/DefaultCrawlScope.java
@@ -1,0 +1,62 @@
+package com.crawljax.core.configuration;
+
+import java.net.URI;
+
+import com.crawljax.util.UrlUtils;
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
+import com.google.common.base.Preconditions;
+
+/**
+ * A {@code CrawlScope} that allows to crawl only under a given domain.
+ * 
+ * @since 3.7
+ */
+public class DefaultCrawlScope implements CrawlScope {
+
+	private URI url;
+
+	/**
+	 * Constructs a {@code DefaultCrawlScope} with the given URL.
+	 * 
+	 * @param url
+	 *            the URL with allowed domain, must not be {@code null}.
+	 */
+	public DefaultCrawlScope(URI url) {
+		Preconditions.checkNotNull(url);
+		this.url = url;
+	}
+
+	/**
+	 * Gets the URL used for scope check.
+	 * 
+	 * @return the URL used for scope check.
+	 */
+	public URI getUrl() {
+		return url;
+	}
+
+	@Override
+	public boolean isInScope(String url) {
+		return UrlUtils.isSameDomain(url, this.url);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hashCode(url);
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (object instanceof DefaultCrawlScope) {
+			DefaultCrawlScope that = (DefaultCrawlScope) object;
+			return Objects.equal(this.url, that.url);
+		}
+		return false;
+	}
+
+	@Override
+	public String toString() {
+		return MoreObjects.toStringHelper(this).add("url", url).toString();
+	}
+}

--- a/core/src/test/java/com/crawljax/core/configuration/CrawljaxConfigurationBuilderTest.java
+++ b/core/src/test/java/com/crawljax/core/configuration/CrawljaxConfigurationBuilderTest.java
@@ -1,6 +1,7 @@
 package com.crawljax.core.configuration;
 
 import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertThat;
 
 import java.io.File;
@@ -48,6 +49,20 @@ public class CrawljaxConfigurationBuilderTest {
 	public void ifCannotCreateOutputFolderReject() throws Exception {
 		File file = new File("/this/should/not/be/writable");
 		testBuilder().setOutputDirectory(file).build();
+	}
+
+	@Test
+	public void shouldReturnDefaultCrawlScopeIfNoneSet() throws Exception {
+		CrawlScope crawlScope = testBuilder().build().getCrawlScope();
+		assertThat(crawlScope, is(instanceOf(DefaultCrawlScope.class)));
+		assertThat(((DefaultCrawlScope) crawlScope).getUrl().toString(), is("http://localhost"));
+	}
+
+	@Test
+	public void shouldReturnCrawlScopeSet() throws Exception {
+		CrawlScope crawlScope = url -> true;
+		CrawljaxConfiguration conf = testBuilder().setCrawlScope(crawlScope).build();
+		assertThat(conf.getCrawlScope(), is(crawlScope));
 	}
 
 	@Test

--- a/core/src/test/java/com/crawljax/core/configuration/DefaultCrawlScopeTest.java
+++ b/core/src/test/java/com/crawljax/core/configuration/DefaultCrawlScopeTest.java
@@ -1,0 +1,30 @@
+package com.crawljax.core.configuration;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+import java.net.URI;
+
+import org.junit.Test;
+
+public class DefaultCrawlScopeTest {
+
+	private static final URI SEED = URI.create("http://localhost/");
+
+	@Test(expected = NullPointerException.class)
+	public void nullSeedDomainIsNotAllowed() throws Exception {
+		new DefaultCrawlScope((URI) null);
+	}
+
+	@Test
+	public void defaultCrawlScopeShouldIncludeSeedDomain() throws Exception {
+		CrawlScope defaultCrawlScope = new DefaultCrawlScope(SEED);
+		assertThat(defaultCrawlScope.isInScope("http://localhost/in/scope"), is(true));
+	}
+
+	@Test
+	public void defaultCrawlScopeShouldNotIncludeNonSeedDomain() throws Exception {
+		CrawlScope defaultCrawlScope = new DefaultCrawlScope(SEED);
+		assertThat(defaultCrawlScope.isInScope("http://example.com/not/in/scope"), is(false));
+	}
+}

--- a/core/src/test/java/com/crawljax/crawls/CrawlWithCustomScopeTest.java
+++ b/core/src/test/java/com/crawljax/crawls/CrawlWithCustomScopeTest.java
@@ -1,0 +1,52 @@
+package com.crawljax.crawls;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsCollectionContaining.hasItems;
+import static org.junit.Assert.assertThat;
+
+import java.net.URI;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import com.crawljax.core.CrawlSession;
+import com.crawljax.core.configuration.CrawlScope;
+import com.crawljax.core.configuration.CrawljaxConfiguration.CrawljaxConfigurationBuilder;
+import com.crawljax.core.state.StateVertex;
+import com.crawljax.test.BaseCrawler;
+import com.crawljax.test.BrowserTest;
+
+@Category(BrowserTest.class)
+public class CrawlWithCustomScopeTest {
+
+	@Test
+	public void crawlsPagesOnlyInCustomScope() throws Exception {
+		CrawlScope crawlScope = url -> url.contains("in_scope") || url.endsWith("crawlscope/");
+		BaseCrawler baseCrawler = new BaseCrawler("crawlscope") {
+			@Override
+			public CrawljaxConfigurationBuilder newCrawlConfigurationBuilder() {
+				CrawljaxConfigurationBuilder builder =
+				        super.newCrawlConfigurationBuilder();
+				builder.setCrawlScope(crawlScope);
+				return builder;
+			}
+		};
+
+		CrawlSession crawlSession = baseCrawler.crawl();
+
+		URI baseUrl = baseCrawler.getWebServer().getSiteUrl();
+		Set<String> crawledUrls = new HashSet<>();
+		for (StateVertex state : crawlSession.getStateFlowGraph().getAllStates()) {
+			crawledUrls.add(state.getUrl());
+		}
+
+		assertThat(crawledUrls, hasItems(
+		        baseUrl + "crawlscope",
+		        baseUrl + "crawlscope/in_scope.html",
+		        baseUrl + "crawlscope/in_scope_inner.html"));
+		assertThat(crawledUrls.size(), is(3));
+	}
+
+}

--- a/core/src/test/resources/site/crawlscope/in_scope.html
+++ b/core/src/test/resources/site/crawlscope/in_scope.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>In Scope</title>
+</head>
+<body>
+	<h1>In Scope</h1>
+	<p>This page can be accessed and crawled.</p>
+	<a href="in_scope_inner.html">inner page</a>
+</body>
+</html>

--- a/core/src/test/resources/site/crawlscope/in_scope_inner.html
+++ b/core/src/test/resources/site/crawlscope/in_scope_inner.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>In Scope Inner Page</title>
+</head>
+<body>
+	<h1>In Scope Inner Page</h1>
+	<p>This page should be accessed.</p>
+</body>
+</html>

--- a/core/src/test/resources/site/crawlscope/index.html
+++ b/core/src/test/resources/site/crawlscope/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Index Scope Test</title>
+</head>
+<body>
+	<h1>Index Scope Test</h1>
+	<p>Pages that are in and out of crawl scope.</p>
+	<a href="out_of_scope.html">out of scope</a>
+	<a href="in_scope.html">in scope</a>
+</body>
+</html>

--- a/core/src/test/resources/site/crawlscope/out_of_scope.html
+++ b/core/src/test/resources/site/crawlscope/out_of_scope.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Out of Scope</title>
+</head>
+<body>
+	<h1>Out of Scope</h1>
+	<p>This page can be accessed but not crawled.</p>
+	<a href="out_of_scope_inner.html">inner page</a>
+</body>
+</html>

--- a/core/src/test/resources/site/crawlscope/out_of_scope_inner.html
+++ b/core/src/test/resources/site/crawlscope/out_of_scope_inner.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Out of Scope Inner Page</title>
+</head>
+<body>
+	<h1>Out of Scope Inner Page</h1>
+	<p>This page should not be accessed.</p>
+</body>
+</html>

--- a/examples/src/main/java/com/crawljax/examples/CrawlScopeExample.java
+++ b/examples/src/main/java/com/crawljax/examples/CrawlScopeExample.java
@@ -1,0 +1,27 @@
+package com.crawljax.examples;
+
+import com.crawljax.core.CrawljaxRunner;
+import com.crawljax.core.configuration.CrawljaxConfiguration;
+import com.crawljax.core.configuration.CrawljaxConfiguration.CrawljaxConfigurationBuilder;
+
+/**
+ * Example of running Crawljax with a custom crawl scope.
+ */
+public final class CrawlScopeExample {
+
+	private static final String URL = "http://example.com/";
+
+	/**
+	 * Run this method to start the crawl.
+	 */
+	public static void main(String[] args) {
+		CrawljaxConfigurationBuilder builder = CrawljaxConfiguration.builderFor(URL);
+
+		// Don't allow to crawl subdomains (default scope crawls subdomains).
+		builder.setCrawlScope(url -> url.startsWith(URL));
+
+		CrawljaxRunner crawljax = new CrawljaxRunner(builder.build());
+		crawljax.call();
+	}
+
+}


### PR DESCRIPTION
Allow to control which of the URLs accessed can be crawled, for example,
to allow to crawl several domains or just some pages under a given
domain.

Related to zaproxy/zap-extensions#468 - spiderAjax: allow choose
context/user and set URL