### PR TITLE
Restore exclusion of integration tests

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -156,6 +156,7 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>
+					<excludedGroups>${tests.exclude}</excludedGroups>
 					<parallel>methods</parallel>
 					<threadCount>4</threadCount>
 					<systemPropertyVariables>


### PR DESCRIPTION
Restore the exclusion of integration tests in the default profile (the
exclusion was removed accidentally(?) in previous change
734c89df5591356f22090015b8c40f015fb20705).