### PR TITLE
Use StringBuilder whenever possible

### DIFF
--- a/core/src/main/java/com/crawljax/core/configuration/ConfigurationHelper.java
+++ b/core/src/main/java/com/crawljax/core/configuration/ConfigurationHelper.java
@@ -18,7 +18,7 @@ public final class ConfigurationHelper {
 	 * @return string representation of list. format: a, b, , c. Empty String allowed
 	 */
 	public static String listToStringEmptyStringAllowed(List<String> items) {
-		StringBuffer str = new StringBuffer();
+		StringBuilder str = new StringBuilder();
 		int i = 0;
 		for (String item : items) {
 			if (i > 0) {
@@ -36,7 +36,7 @@ public final class ConfigurationHelper {
 	 * @return string representation of list. format: a, b, c
 	 */
 	public static String listToString(List<?> items) {
-		StringBuffer str = new StringBuffer();
+		StringBuilder str = new StringBuilder();
 		for (Object item : items) {
 			if (!str.toString().equals("")) {
 				str.append(", ");

--- a/core/src/main/java/com/crawljax/forms/RandomInputValueGenerator.java
+++ b/core/src/main/java/com/crawljax/forms/RandomInputValueGenerator.java
@@ -23,12 +23,12 @@ public class RandomInputValueGenerator {
 	 * @return a random string
 	 */
 	private String generate(String characters, int length) {
-		StringBuffer buf = new StringBuffer();
+		StringBuilder strBuilder = new StringBuilder();
 		for (int i = 0; i < length; i++) {
 			int index = new Random().nextInt(characters.length());
-			buf.append(characters.substring(index, index + 1));
+			strBuilder.append(characters.substring(index, index + 1));
 		}
-		return buf.toString();
+		return strBuilder.toString();
 	}
 
 	/**

--- a/core/src/main/java/com/crawljax/util/XPathHelper.java
+++ b/core/src/main/java/com/crawljax/util/XPathHelper.java
@@ -55,14 +55,14 @@ public final class XPathHelper {
 			return xPath;
 		}
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder strBuilder = new StringBuilder();
 
 		if (parent != node) {
-			buffer.append(getXPathExpression(parent));
-			buffer.append("/");
+			strBuilder.append(getXPathExpression(parent));
+			strBuilder.append("/");
 		}
 
-		buffer.append(node.getNodeName());
+		strBuilder.append(node.getNodeName());
 
 		List<Node> mySiblings = getSiblings(parent, node);
 
@@ -70,12 +70,12 @@ public final class XPathHelper {
 			Node el = mySiblings.get(i);
 
 			if (el.equals(node)) {
-				buffer.append('[').append(Integer.toString(i + 1)).append(']');
+				strBuilder.append('[').append(Integer.toString(i + 1)).append(']');
 				// Found so break;
 				break;
 			}
 		}
-		String xPath = buffer.toString();
+		String xPath = strBuilder.toString();
 		node.setUserData(FULL_XPATH_CACHE, xPath, null);
 		return xPath;
 	}


### PR DESCRIPTION
Replace usage of StringBuffer with StringBuilder where the
synchronisation of the former is not required (and rename the variable
to match the new object).