### PR TITLE
Use specified browser in (all) browser tests

### DIFF
--- a/core/src/test/java/com/crawljax/core/IFrameTest.java
+++ b/core/src/test/java/com/crawljax/core/IFrameTest.java
@@ -30,8 +30,7 @@ public class IFrameTest {
 	public static final RunWithWebServer WEB_SERVER = new RunWithWebServer("/site");
 
 	protected CrawljaxConfigurationBuilder setupConfig() {
-		CrawljaxConfigurationBuilder builder =
-		        CrawljaxConfiguration.builderFor(WEB_SERVER.getSiteUrl().resolve("iframe"));
+		CrawljaxConfigurationBuilder builder = WEB_SERVER.newConfigBuilder("iframe");
 		builder.crawlRules().waitAfterEvent(100, TimeUnit.MILLISECONDS);
 		builder.crawlRules().waitAfterReloadUrl(100, TimeUnit.MILLISECONDS);
 		builder.setMaximumDepth(3);

--- a/core/src/test/java/com/crawljax/core/PassBasicHttpAuthTest.java
+++ b/core/src/test/java/com/crawljax/core/PassBasicHttpAuthTest.java
@@ -18,6 +18,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+import com.crawljax.browser.BrowserProvider;
+import com.crawljax.core.configuration.BrowserConfiguration;
 import com.crawljax.core.configuration.CrawljaxConfiguration;
 import com.crawljax.core.configuration.CrawljaxConfiguration.CrawljaxConfigurationBuilder;
 import com.crawljax.test.BrowserTest;
@@ -73,6 +75,8 @@ public class PassBasicHttpAuthTest {
 		        CrawljaxConfiguration.builderFor(url);
 		builder.setMaximumStates(3);
 		builder.setBasicAuth(USERNAME, PASSWORD);
+		builder.setBrowserConfig(
+		        new BrowserConfiguration(BrowserProvider.getBrowserType()));
 		CrawlSession session = new CrawljaxRunner(builder.build()).call();
 
 		assertThat(session.getStateFlowGraph(), hasStates(3));

--- a/core/src/test/java/com/crawljax/core/PopUpTest.java
+++ b/core/src/test/java/com/crawljax/core/PopUpTest.java
@@ -10,7 +10,6 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import com.crawljax.core.configuration.CrawljaxConfiguration;
 import com.crawljax.core.configuration.CrawljaxConfiguration.CrawljaxConfigurationBuilder;
 import com.crawljax.test.BrowserTest;
 import com.crawljax.test.RunWithWebServer;
@@ -23,8 +22,7 @@ public class PopUpTest {
 
 	@Test
 	public void testPopups() throws CrawljaxException {
-		CrawljaxConfigurationBuilder builder =
-		        CrawljaxConfiguration.builderFor(WEB_SERVER.getSiteUrl().resolve("popup"));
+		CrawljaxConfigurationBuilder builder = WEB_SERVER.newConfigBuilder("popup");
 		builder.setMaximumDepth(3);
 		builder.crawlRules().click("a");
 		builder.crawlRules().waitAfterEvent(100, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
Change IFrameTest, PassBasicHttpAuthTest, and PopUpTest to use the
specified browser (property "test.browser"), not always Firefox.