### PR TITLE
Correct browser test tagging

### DIFF
--- a/core/src/test/java/com/crawljax/core/plugin/PluginsTest.java
+++ b/core/src/test/java/com/crawljax/core/plugin/PluginsTest.java
@@ -12,7 +12,6 @@ import java.util.Map.Entry;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -29,13 +28,11 @@ import com.crawljax.core.configuration.CrawljaxConfiguration;
 import com.crawljax.core.state.Eventable;
 import com.crawljax.core.state.StateVertex;
 import com.crawljax.metrics.MetricsModule;
-import com.crawljax.test.BrowserTest;
 import com.google.common.collect.ImmutableList;
 
 /**
  * Test cases to test the running and correct functioning of the plugins. Used to address issue #26
  */
-@Category(BrowserTest.class)
 @RunWith(MockitoJUnitRunner.class)
 public class PluginsTest {
 

--- a/core/src/test/java/com/crawljax/core/state/StateVertexFactoryTest.java
+++ b/core/src/test/java/com/crawljax/core/state/StateVertexFactoryTest.java
@@ -8,10 +8,13 @@ import com.crawljax.core.CrawlSession;
 import com.crawljax.core.CrawljaxRunner;
 import com.crawljax.core.ExitNotifier;
 import com.crawljax.core.configuration.CrawljaxConfiguration;
+import com.crawljax.test.BrowserTest;
 import com.crawljax.test.RunWithWebServer;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(BrowserTest.class)
 public class StateVertexFactoryTest {
 
 	@ClassRule

--- a/core/src/test/java/com/crawljax/core/state/StatesContainElementsTest.java
+++ b/core/src/test/java/com/crawljax/core/state/StatesContainElementsTest.java
@@ -10,11 +10,14 @@ import java.util.Set;
 import org.eclipse.jetty.util.resource.Resource;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import com.crawljax.core.CrawlSession;
 import com.crawljax.core.configuration.CrawljaxConfiguration.CrawljaxConfigurationBuilder;
 import com.crawljax.test.BaseCrawler;
+import com.crawljax.test.BrowserTest;
 
+@Category(BrowserTest.class)
 public class StatesContainElementsTest {
 
 	private CrawlSession crawl;


### PR DESCRIPTION
Remove the "browser test" tag from PluginsTest and add it to
StateVertexFactoryTest and StatesContainElementsTest, first class does
not use a browser, last two do use it.