### PR TITLE
Require PhantomJS binary to run its tests

### DIFF
--- a/core/src/test/java/com/crawljax/core/largetests/LargeChromeTest.java
+++ b/core/src/test/java/com/crawljax/core/largetests/LargeChromeTest.java
@@ -11,7 +11,7 @@ public class LargeChromeTest extends LargeTestBase {
 
 	@BeforeClass
 	public static void setUpBeforeClass() throws Exception {
-		assumeWebDriver("webdriver.chrome.driver", "chromedriver");
+		assumeBinary("webdriver.chrome.driver", "chromedriver");
 	}
 
 	@Override

--- a/core/src/test/java/com/crawljax/core/largetests/LargeFirefoxTest.java
+++ b/core/src/test/java/com/crawljax/core/largetests/LargeFirefoxTest.java
@@ -12,7 +12,7 @@ public class LargeFirefoxTest extends LargeTestBase {
 
 	@BeforeClass
 	public static void setUpBeforeClass() throws Exception {
-		assumeWebDriver("webdriver.gecko.driver", "geckodriver");
+		assumeBinary("webdriver.gecko.driver", "geckodriver");
 	}
 
 	@Override

--- a/core/src/test/java/com/crawljax/core/largetests/LargePhantomJSTest.java
+++ b/core/src/test/java/com/crawljax/core/largetests/LargePhantomJSTest.java
@@ -3,10 +3,17 @@ package com.crawljax.core.largetests;
 import com.crawljax.browser.EmbeddedBrowser.BrowserType;
 import com.crawljax.core.configuration.BrowserConfiguration;
 import com.crawljax.test.BrowserTest;
+
+import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
 @Category(BrowserTest.class)
 public class LargePhantomJSTest extends LargeTestBase {
+
+	@BeforeClass
+	public static void setUpBeforeClass() throws Exception {
+		assumeBinary("phantomjs.binary.path", "phantomjs");
+	}
 
 	@Override
 	BrowserConfiguration getBrowserConfiguration() {

--- a/core/src/test/java/com/crawljax/core/largetests/LargeTestBase.java
+++ b/core/src/test/java/com/crawljax/core/largetests/LargeTestBase.java
@@ -114,7 +114,7 @@ public abstract class LargeTestBase {
 	@Rule
 	public final Timeout timeout = new Timeout((int) TimeUnit.MINUTES.toMillis(15));
 
-	protected static void assumeWebDriver(String systemProperty, String binaryName) throws Exception {
+	protected static void assumeBinary(String systemProperty, String binaryName) throws Exception {
 		assumeThat(System.getProperty(systemProperty) != null
 		  || isOnClassPath(binaryName), is(true));
 	}


### PR DESCRIPTION
Change LargePhantomJSTest to require the phantomjs binary to run the
tests, instead of failing the build if the binary is not available.
Refactor the code to use the same logic as for checking the WebDriver
binary (both can be set as a property or be on the PATH).