### PR TITLE
Handle UOE when executing a JavaScript script

### DIFF
--- a/core/src/main/java/com/crawljax/browser/WebDriverBackedEmbeddedBrowser.java
+++ b/core/src/main/java/com/crawljax/browser/WebDriverBackedEmbeddedBrowser.java
@@ -510,6 +510,10 @@ public final class WebDriverBackedEmbeddedBrowser implements EmbeddedBrowser {
 		try {
 			JavascriptExecutor js = (JavascriptExecutor) browser;
 			return js.executeScript(code);
+		} catch (UnsupportedOperationException e) {
+			// HtmlUnitDriver throws UnsupportedOperationException if it can't execute the
+			// JavaScript, for example, "Cannot execute JS against a plain text page".
+			throw new CrawljaxException(e);
 		} catch (WebDriverException e) {
 			throwIfConnectionException(e);
 			throw new CrawljaxException(e);


### PR DESCRIPTION
Change WebDriverBackedEmbeddedBrowser to catch the exception
UnsupportedOperationException when executing a JavaScript script, that
might be thrown by HtmlUnitDriver if the target page is not HTML (e.g.
plain text).