### PR TITLE
Correct test name in PassBasicHttpAuthTest

### DIFF
--- a/core/src/test/java/com/crawljax/core/PassBasicHttpAuthTest.java
+++ b/core/src/test/java/com/crawljax/core/PassBasicHttpAuthTest.java
@@ -69,7 +69,7 @@ public class PassBasicHttpAuthTest {
 	}
 
 	@Test
-	public void testDontClickUnderXPath() throws Exception {
+	public void testProvidedCredentialsAreUsedInBasicAuth() throws Exception {
 		String url = "http://localhost:" + port + "/infinite.html";
 		CrawljaxConfigurationBuilder builder =
 		        CrawljaxConfiguration.builderFor(url);


### PR DESCRIPTION
Change the name of the existing method/test to describe what is actually
being tested (it was using a name from other class).