### PR TITLE
Log with parameterized messages

### DIFF
--- a/core/src/main/java/com/crawljax/browser/WebDriverBackedEmbeddedBrowser.java
+++ b/core/src/main/java/com/crawljax/browser/WebDriverBackedEmbeddedBrowser.java
@@ -462,7 +462,7 @@ public final class WebDriverBackedEmbeddedBrowser implements EmbeddedBrowser {
 			boolean result = false;
 
 			if (eventable.getRelatedFrame() != null && !eventable.getRelatedFrame().equals("")) {
-				LOGGER.debug("switching to frame: " + eventable.getRelatedFrame());
+				LOGGER.debug("switching to frame: {}", eventable.getRelatedFrame());
 				try {
 
 					switchToFrame(eventable.getRelatedFrame());
@@ -634,13 +634,13 @@ public final class WebDriverBackedEmbeddedBrowser implements EmbeddedBrowser {
 
 			String handle = browser.getWindowHandle();
 
-			LOGGER.debug("The current H: " + handle);
+			LOGGER.debug("The current H: {}", handle);
 
 			switchToFrame(frameIdentification);
 
 			String toAppend = browser.getPageSource();
 
-			LOGGER.debug("frame dom: " + toAppend);
+			LOGGER.debug("frame dom: {}", toAppend);
 
 			browser.switchTo().defaultContent();
 
@@ -652,20 +652,20 @@ public final class WebDriverBackedEmbeddedBrowser implements EmbeddedBrowser {
 
 				appendFrameContent(importedElement, document, frameIdentification);
 			} catch (DOMException | IOException e) {
-				LOGGER.info("Got exception while inspecting a frame:" + frameIdentification
-				        + " continuing...", e);
+				LOGGER.info("Got exception while inspecting a frame: {} continuing...",
+				        frameIdentification, e);
 			}
 		}
 	}
 
 	private void switchToFrame(String frameIdentification) throws NoSuchFrameException {
-		LOGGER.debug("frame identification: " + frameIdentification);
+		LOGGER.debug("frame identification: {}", frameIdentification);
 
 		if (frameIdentification.contains(".")) {
 			String[] frames = frameIdentification.split("\\.");
 
 			for (String frameId : frames) {
-				LOGGER.debug("switching to frame: " + frameId);
+				LOGGER.debug("switching to frame: {}", frameId);
 				browser.switchTo().frame(frameId);
 			}
 

--- a/core/src/main/java/com/crawljax/browser/WebDriverBrowserBuilder.java
+++ b/core/src/main/java/com/crawljax/browser/WebDriverBrowserBuilder.java
@@ -82,7 +82,7 @@ public class WebDriverBrowserBuilder implements Provider<EmbeddedBrowser> {
 					        + configuration.getBrowserConfig().getBrowsertype());
 			}
 		} catch (IllegalStateException e) {
-			LOGGER.error("Crawling with {} failed: " + e.getMessage(), browserType.toString());
+			LOGGER.error("Crawling with {} failed: {}", browserType.toString(), e.getMessage());
 			throw e;
 		}
 		plugins.runOnBrowserCreatedPlugins(browser);

--- a/core/src/main/java/com/crawljax/condition/browserwaiter/WaitCondition.java
+++ b/core/src/main/java/com/crawljax/condition/browserwaiter/WaitCondition.java
@@ -91,12 +91,12 @@ public class WaitCondition {
 		long currentTime = System.currentTimeMillis();
 		long maxTime = currentTime + this.timeOut;
 		long repeatTime = this.pollingTime;
-		LOGGER.info("Waiting for " + toCheckwaitConditions.size() + " conditions");
+		LOGGER.info("Waiting for {} conditions", toCheckwaitConditions.size());
 		int index = 0;
 		while (index < toCheckwaitConditions.size() && currentTime <= maxTime) {
 			ExpectedCondition checkCondition = toCheckwaitConditions.get(index);
 			lastCheckCondition = checkCondition;
-			LOGGER.debug("Waiting for: " + checkCondition);
+			LOGGER.debug("Waiting for: {}", checkCondition);
 			if (checkCondition.isSatisfied(browser)) {
 				index++;
 			} else {
@@ -110,8 +110,8 @@ public class WaitCondition {
 			currentTime = System.currentTimeMillis();
 		}
 		if (currentTime >= maxTime) {
-			LOGGER.info("TIMEOUT WaitCondition url " + getUrl() + "; Timout while waiting for "
-			        + lastCheckCondition);
+			LOGGER.info("TIMEOUT WaitCondition url {}; Timout while waiting for {}",
+			        getUrl(), lastCheckCondition);
 			return 0;
 		} else {
 			return 1;

--- a/core/src/main/java/com/crawljax/condition/browserwaiter/WaitConditionChecker.java
+++ b/core/src/main/java/com/crawljax/condition/browserwaiter/WaitConditionChecker.java
@@ -45,7 +45,7 @@ public class WaitConditionChecker {
 			return;
 		}
 		for (WaitCondition waitCondition : waitConditions) {
-			LOGGER.info("Checking WaitCondition for url: " + waitCondition.getUrl());
+			LOGGER.info("Checking WaitCondition for url: {}", waitCondition.getUrl());
 			waitCondition.testAndWait(browser);
 		}
 	}

--- a/core/src/main/java/com/crawljax/forms/FormHandler.java
+++ b/core/src/main/java/com/crawljax/forms/FormHandler.java
@@ -196,7 +196,7 @@ public class FormHandler {
 		try {
 			Document dom = DomUtils.asDocument(browser.getStrippedDomWithoutIframeContent());
 			for (FormInput input : formInputs) {
-				LOGGER.debug("Filling in: " + input);
+				LOGGER.debug("Filling in: {}", input);
 				setInputElementValue(formInputValueHelper.getBelongingNode(input, dom), input);
 			}
 		} catch (IOException | XPathExpressionException e) {

--- a/core/src/main/java/com/crawljax/forms/FormInputValueHelper.java
+++ b/core/src/main/java/com/crawljax/forms/FormInputValueHelper.java
@@ -198,8 +198,8 @@ public final class FormInputValueHelper {
 			break;
 
 		default:
-			LOGGER.info("Identification " + input.getIdentification()
-					+ " not supported yet for form inputs.");
+			LOGGER.info("Identification {} not supported yet for form inputs.",
+			        input.getIdentification());
 			break;
 
 		}

--- a/core/src/main/java/com/crawljax/oraclecomparator/StateComparator.java
+++ b/core/src/main/java/com/crawljax/oraclecomparator/StateComparator.java
@@ -64,7 +64,7 @@ public class StateComparator {
 	private boolean allPreConditionsSucceed(OracleComparator oraclePreCondition,
 	        EmbeddedBrowser browser) {
 		for (Condition preCondition : oraclePreCondition.getPreConditions()) {
-			LOGGER.debug("Check precondition: " + preCondition.toString());
+			LOGGER.debug("Check precondition: {}", preCondition.toString());
 			if (!preCondition.check(browser)) {
 				return false;
 			}

--- a/core/src/main/java/com/crawljax/oraclecomparator/comparators/StyleComparator.java
+++ b/core/src/main/java/com/crawljax/oraclecomparator/comparators/StyleComparator.java
@@ -88,10 +88,10 @@ public class StyleComparator extends AbstractComparator {
 					parent.removeChild(removeNode);
 				}
 			} catch (XPathExpressionException e) {
-				LOGGER.warn("Error with StyleOracle: " + e.getMessage());
+				LOGGER.warn("Error with StyleOracle: {}", e.getMessage());
 				LOGGER.error(e.getMessage(), e);
 			} catch (DOMException e) {
-				LOGGER.warn("Error with StyleOracle: " + e.getMessage());
+				LOGGER.warn("Error with StyleOracle: {}", e.getMessage());
 				LOGGER.error(e.getMessage(), e);
 			}
 		}
@@ -108,9 +108,9 @@ public class StyleComparator extends AbstractComparator {
 					attributes.removeNamedItem(attribute);
 				}
 			} catch (XPathExpressionException e) {
-				LOGGER.warn("Error with StyleOracle: " + e.getMessage());
+				LOGGER.warn("Error with StyleOracle: {}", e.getMessage());
 			} catch (DOMException e) {
-				LOGGER.warn("Error with StyleOracle: " + e.getMessage());
+				LOGGER.warn("Error with StyleOracle: {}", e.getMessage());
 			}
 		}
 		return dom;

--- a/core/src/main/java/com/crawljax/oraclecomparator/comparators/XPathExpressionComparator.java
+++ b/core/src/main/java/com/crawljax/oraclecomparator/comparators/XPathExpressionComparator.java
@@ -72,7 +72,7 @@ public class XPathExpressionComparator extends AbstractComparator {
 				}
 			}
 		} catch (XPathExpressionException | DOMException | IOException e) {
-			LOGGER.error("Exception with stripping XPath expression: " + curExpression, e);
+			LOGGER.error("Exception with stripping XPath expression: {}", curExpression, e);
 		} finally {
 			if (doc != null) {
 				domRet = DomUtils.getDocumentToString(doc);

--- a/core/src/main/java/com/crawljax/util/DomUtils.java
+++ b/core/src/main/java/com/crawljax/util/DomUtils.java
@@ -224,7 +224,7 @@ public final class DomUtils {
 						"//" + tagName.toUpperCase());
 			}
 		} catch (XPathExpressionException e) {
-			LOGGER.error("Error while removing tag " + tagName, e);
+			LOGGER.error("Error while removing tag {}", tagName, e);
 		}
 
 		return dom;
@@ -356,7 +356,7 @@ public final class DomUtils {
 
 			return dd.getAllDifferences();
 		} catch (IOException e) {
-			LOGGER.error("Error with getDifferences: " + e.getMessage(), e);
+			LOGGER.error("Error with getDifferences: {}", e.getMessage(), e);
 		}
 		return null;
 	}

--- a/core/src/main/java/com/crawljax/util/ElementResolver.java
+++ b/core/src/main/java/com/crawljax/util/ElementResolver.java
@@ -78,7 +78,7 @@ public class ElementResolver {
 			        XPathHelper.evaluateXpathExpression(dom, "//"
 			                + eventable.getElement().getTag().toUpperCase());
 			if (logging) {
-				LOGGER.info("Candidates: " + candidateElements.getLength());
+				LOGGER.info("Candidates: {}", candidateElements.getLength());
 			}
 			for (int i = 0; i < candidateElements.getLength(); i++) {
 				Element candidateElement = new Element(candidateElements.item(i));


### PR DESCRIPTION
Change log statements to use parameterized messages (instead of string
concatenations), to avoid unnecessary work when the message is not
actually logged.