### PR TITLE
Terminate WebDrivers, always

### DIFF
--- a/core/src/main/java/com/crawljax/core/CrawlTaskConsumer.java
+++ b/core/src/main/java/com/crawljax/core/CrawlTaskConsumer.java
@@ -47,13 +47,17 @@ public class CrawlTaskConsumer implements Callable<Void> {
 				pollAndHandleCrawlTasks();
 				runningConsumers.decrementAndGet();
 			}
-			crawler.close();
 		} catch (InterruptedException e) {
 			LOG.debug("Consumer interrupted");
-			crawler.close();
 		} catch (RuntimeException e) {
 			LOG.error("Unexpected error " + e.getMessage(), e);
 			throw e;
+		} finally {
+			try {
+				crawler.close();
+			} catch (Exception e) {
+				LOG.error("Error occurred while closing the browser:", e);
+			}
 		}
 		return null;
 	}


### PR DESCRIPTION
Change CrawlTaskConsumer to always close the browser (in a finally
block).
Change WebDriverBackedEmbeddedBrowser to close/quit the browser in a
different thread than the one being called to avoid interruptions, which
could prevent the WebDriver (e.g. chromedriver, geckodriver) from being
terminated, leading to process leaks.

Related to zaproxy/zaproxy#3155 - WebDriver process leak with AJAX
Spider