### PR TITLE
Remove redundant version specification

### DIFF
--- a/plugins/crawloverview-plugin/pom.xml
+++ b/plugins/crawloverview-plugin/pom.xml
@@ -82,7 +82,6 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>${selenium.version}</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -81,7 +81,6 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>${selenium.version}</version>
 			<scope>test</scope>
 			<exclusions>
 				<exclusion>


### PR DESCRIPTION
Remove redundant version specification of Selenium dependency in modules
crawloverview-plugin and web, already defined by parent POM.