### PR TITLE
Update Selenium library

### DIFF
--- a/cli/src/test/java/com/crawljax/cli/LogUtilTest.java
+++ b/cli/src/test/java/com/crawljax/cli/LogUtilTest.java
@@ -78,7 +78,7 @@ public class LogUtilTest {
 		LoggerFactory.getLogger(CrawljaxRunner.class).warn("Test123");
 
 		assertThat(file.exists(), is(true));
-		assertThat(Files.toString(file, Charsets.UTF_8), containsString("Test123"));
+		assertThat(Files.asCharSource(file, Charsets.UTF_8).read(), containsString("Test123"));
 		assertThat(system.getConsoleOutput(), not(containsString("Test123")));
 	}
 }

--- a/core/src/main/java/com/crawljax/browser/WebDriverBrowserBuilder.java
+++ b/core/src/main/java/com/crawljax/browser/WebDriverBrowserBuilder.java
@@ -12,7 +12,7 @@ import com.google.common.collect.ImmutableSortedSet;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.firefox.FirefoxDriver;
-import org.openqa.selenium.firefox.FirefoxProfile;
+import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.ie.InternetExplorerDriver;
 import org.openqa.selenium.phantomjs.PhantomJSDriver;
 import org.openqa.selenium.phantomjs.PhantomJSDriverService;
@@ -91,27 +91,25 @@ public class WebDriverBrowserBuilder implements Provider<EmbeddedBrowser> {
 
 	private EmbeddedBrowser newFireFoxBrowser(ImmutableSortedSet<String> filterAttributes,
 	        long crawlWaitReload, long crawlWaitEvent) {
+		FirefoxOptions options = new FirefoxOptions();
 		if (configuration.getProxyConfiguration() != null) {
-			FirefoxProfile profile = new FirefoxProfile();
 			String lang = configuration.getBrowserConfig().getLangOrNull();
 			if (!Strings.isNullOrEmpty(lang)) {
-				profile.setPreference("intl.accept_languages", lang);
+				options.addPreference("intl.accept_languages", lang);
 			}
 
-			profile.setPreference("network.proxy.http", configuration.getProxyConfiguration()
+			options.addPreference("network.proxy.http", configuration.getProxyConfiguration()
 			        .getHostname());
-			profile.setPreference("network.proxy.http_port", configuration
+			options.addPreference("network.proxy.http_port", configuration
 			        .getProxyConfiguration().getPort());
-			profile.setPreference("network.proxy.type", configuration.getProxyConfiguration()
+			options.addPreference("network.proxy.type", configuration.getProxyConfiguration()
 			        .getType().toInt());
 			/* use proxy for everything, including localhost */
-			profile.setPreference("network.proxy.no_proxies_on", "");
-
-			return WebDriverBackedEmbeddedBrowser.withDriver(new FirefoxDriver(profile),
-			        filterAttributes, crawlWaitReload, crawlWaitEvent);
+			options.addPreference("network.proxy.no_proxies_on", "");
 		}
 
-		return WebDriverBackedEmbeddedBrowser.withDriver(new FirefoxDriver(), filterAttributes,
+		return WebDriverBackedEmbeddedBrowser.withDriver(new FirefoxDriver(options),
+		        filterAttributes,
 		        crawlWaitEvent, crawlWaitReload);
 	}
 

--- a/plugins/crawloverview-plugin/src/main/java/com/crawljax/plugins/crawloverview/OutputBuilder.java
+++ b/plugins/crawloverview-plugin/src/main/java/com/crawljax/plugins/crawloverview/OutputBuilder.java
@@ -184,7 +184,8 @@ class OutputBuilder {
 
 	private void writeJsonToOutDir(String outModelJson, String filename) {
 		try {
-			Files.write(outModelJson, new File(this.outputDir, filename), Charsets.UTF_8);
+			Files.asCharSink(new File(this.outputDir, filename), Charsets.UTF_8)
+			        .write(outModelJson);
 		} catch (IOException e) {
 			LOG.warn("Could not write JSON model to output dir. " + e.getMessage());
 		}
@@ -217,7 +218,8 @@ class OutputBuilder {
 	 */
 	void persistDom(String name, @Nullable String dom) {
 		try {
-			Files.write(Strings.nullToEmpty(dom), new File(doms, name + ".html"), Charsets.UTF_8);
+			Files.asCharSink(new File(doms, name + ".html"), Charsets.UTF_8)
+			        .write(Strings.nullToEmpty(dom));
 		} catch (IOException e) {
 			LOG.warn("Could not save dom state for {}", name);
 			LOG.debug("Could not save dom state", e);
@@ -226,7 +228,7 @@ class OutputBuilder {
 
 	String getDom(String name) {
 		try {
-			return Files.toString(new File(doms, name + ".html"), Charsets.UTF_8);
+			return Files.asCharSource(new File(doms, name + ".html"), Charsets.UTF_8).read();
 		} catch (IOException e) {
 			return "Could not load DOM: " + e.getLocalizedMessage();
 		}

--- a/plugins/crawloverview-plugin/src/test/java/com/crawljax/plugins/crawloverview/ImageWriterTest.java
+++ b/plugins/crawloverview-plugin/src/test/java/com/crawljax/plugins/crawloverview/ImageWriterTest.java
@@ -15,8 +15,8 @@ import com.google.common.io.Files;
 
 public class ImageWriterTest {
 
-	private static final String THUMB_HASH = "b0bd23b784b853ff760c8fb9becd25d8";
-	private static final String FULL_HASH = "df08f0343e11a92424099c8419856441";
+	private static final String THUMB_HASH = "4040cc9bb7aaea0eebdc2879055eb68b";
+	private static final String FULL_HASH = "84254c0309e738b13dc3968414dcae5a";
 
 	@Rule
 	public final TemporaryFolder folder = new TemporaryFolder();
@@ -31,11 +31,11 @@ public class ImageWriterTest {
 		        thumbnail);
 
 		assertThat("Thumbnail exists", thumbnail.exists(), is(true));
-		String hash = Files.hash(thumbnail, Hashing.md5()).toString();
+		String hash = Files.asByteSource(thumbnail).hash(Hashing.murmur3_128()).toString();
 		assertThat("Thumb hash doesn't match", hash, is(THUMB_HASH));
 
 		assertThat("Screenshot exists", fullScreenShot.exists(), is(true));
-		hash = Files.hash(fullScreenShot, Hashing.md5()).toString();
+		hash = Files.asByteSource(fullScreenShot).hash(Hashing.murmur3_128()).toString();
 		assertThat("Screenshot hash doesn't match", hash, is(FULL_HASH));
 	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -33,9 +33,9 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<slf4j.version>1.7.25</slf4j.version>
 		<logback.version>1.2.3</logback.version>
-		<selenium.version>3.4.0</selenium.version>
+		<selenium.version>3.5.3</selenium.version>
 		<!-- Guava version used by Crawljax needs to be compatible with the one used by Selenium, otherwise JAR hell. -->
-		<guava.version>21.0</guava.version>
+		<guava.version>23.0</guava.version>
 		<jetty.version>9.4.6.v20170531</jetty.version>
 		<metrics.version>3.0.2</metrics.version>
 	</properties>

--- a/web/src/main/java/com/crawljax/web/LoggingSocket.java
+++ b/web/src/main/java/com/crawljax/web/LoggingSocket.java
@@ -41,7 +41,7 @@ public class LoggingSocket extends WebSocketAdapter {
 				LOG.debug("Reading the log file");
 				String asString =
 				        "log-<p>"
-				                + Files.toString(log, Charsets.UTF_8).replace(
+				                + Files.asCharSource(log, Charsets.UTF_8).read().replace(
 				                        System.getProperty("line.separator"), "</p><p>");
 				asString = asString.substring(0, asString.length() - 4); // Remove last <p>
 				LOG.debug("Sending the log file");


### PR DESCRIPTION
Update Selenium (3.5.3) and Guava (23, same version as Selenium).
Update codebase to not use deprecated code from Selenium and Guava.

Related to zaproxy/zaproxy#3830 - Update to Selenium 3.5