### PR TITLE
Start browsers in headless mode by default

### DIFF
--- a/core/src/main/java/com/crawljax/browser/WebDriverBrowserBuilder.java
+++ b/core/src/main/java/com/crawljax/browser/WebDriverBrowserBuilder.java
@@ -26,6 +26,7 @@ import org.slf4j.LoggerFactory;
 public class WebDriverBrowserBuilder implements Provider<EmbeddedBrowser> {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(WebDriverBrowserBuilder.class);
+	private static final String HEADLESS_ARG = "--headless";
 	private final CrawljaxConfiguration configuration;
 	private final Plugins plugins;
 
@@ -108,6 +109,10 @@ public class WebDriverBrowserBuilder implements Provider<EmbeddedBrowser> {
 			options.addPreference("network.proxy.no_proxies_on", "");
 		}
 
+		if (configuration.getBrowserConfig().isHeadless()) {
+			options.addArguments(HEADLESS_ARG);
+		}
+
 		return WebDriverBackedEmbeddedBrowser.withDriver(new FirefoxDriver(options),
 		        filterAttributes,
 		        crawlWaitEvent, crawlWaitReload);
@@ -115,10 +120,9 @@ public class WebDriverBrowserBuilder implements Provider<EmbeddedBrowser> {
 
 	private EmbeddedBrowser newChromeBrowser(ImmutableSortedSet<String> filterAttributes,
 	        long crawlWaitReload, long crawlWaitEvent) {
-		ChromeDriver driverChrome;
+		ChromeOptions optionsChrome = new ChromeOptions();
 		if (configuration.getProxyConfiguration() != null
 		        && configuration.getProxyConfiguration().getType() != ProxyType.NOTHING) {
-			ChromeOptions optionsChrome = new ChromeOptions();
 			String lang = configuration.getBrowserConfig().getLangOrNull();
 			if (!Strings.isNullOrEmpty(lang)) {
 				optionsChrome.addArguments("--lang=" + lang);
@@ -126,12 +130,13 @@ public class WebDriverBrowserBuilder implements Provider<EmbeddedBrowser> {
 			optionsChrome.addArguments("--proxy-server=http://"
 			        + configuration.getProxyConfiguration().getHostname() + ":"
 			        + configuration.getProxyConfiguration().getPort());
-			driverChrome = new ChromeDriver(optionsChrome);
-		} else {
-			driverChrome = new ChromeDriver();
 		}
 
-		return WebDriverBackedEmbeddedBrowser.withDriver(driverChrome, filterAttributes,
+		if (configuration.getBrowserConfig().isHeadless()) {
+			optionsChrome.addArguments(HEADLESS_ARG);
+		}
+
+		return WebDriverBackedEmbeddedBrowser.withDriver(new ChromeDriver(optionsChrome), filterAttributes,
 		        crawlWaitEvent, crawlWaitReload);
 	}
 

--- a/core/src/main/java/com/crawljax/core/configuration/BrowserConfiguration.java
+++ b/core/src/main/java/com/crawljax/core/configuration/BrowserConfiguration.java
@@ -46,6 +46,7 @@ public class BrowserConfiguration {
 	private final Provider<EmbeddedBrowser> browserBuilder;
 	private String remoteHubUrl;
 	private String lang;
+	private boolean headless;
 
 	/**
 	 * @param numberOfBrowsers
@@ -101,6 +102,7 @@ public class BrowserConfiguration {
 		this.browsertype = browsertype;
 		this.numberOfBrowsers = numberOfBrowsers;
 		this.browserBuilder = builder;
+		this.headless = true;
 	}
 
 	public BrowserType getBrowsertype() {
@@ -123,6 +125,39 @@ public class BrowserConfiguration {
 		return browserBuilder.equals(DEFAULT_BROWSER_BUILDER);
 	}
 
+	/**
+	 * Tells whether or not the chosen browser should be started in headless mode.
+	 * <p>
+	 * This should be considered a hint, not all browsers support this feature (nor all browsers
+	 * have a GUI).
+	 * <p>
+	 * The default is {@code true}.
+	 * 
+	 * @return {@code true} if the browser should be started in headless mode, {@code false}
+	 *         otherwise.
+	 * @since 3.8
+	 * @see #setHeadless(boolean)
+	 */
+	public boolean isHeadless() {
+		return headless;
+	}
+
+	/**
+	 * Sets whether or not the chosen browser should be started in headless mode.
+	 * <p>
+	 * This should be considered a hint, not all browsers support this feature (nor all browsers
+	 * have a GUI).
+	 *
+	 * @param headless
+	 *            {@code true} if the browser should be started in headless mode, {@code false}
+	 *            otherwise.
+	 * @since 3.8
+	 * @see #isHeadless()
+	 */
+	public void setHeadless(boolean headless) {
+		this.headless = headless;
+	}
+
 	@Override
 	public String toString() {
 		return MoreObjects.toStringHelper(this)
@@ -131,13 +166,14 @@ public class BrowserConfiguration {
 		        .add("browserBuilder", browserBuilder)
 		        .add("remoteHubUrl", remoteHubUrl)
 		        .add("language", lang)
+		        .add("headless", headless)
 		        .toString();
 	}
 
 	@Override
 	public int hashCode() {
 		return Objects.hashCode(browsertype, numberOfBrowsers, browserBuilder,
-		        remoteHubUrl, lang);
+		        remoteHubUrl, lang, headless);
 	}
 
 	@Override
@@ -148,7 +184,8 @@ public class BrowserConfiguration {
 			        && Objects.equal(this.numberOfBrowsers, that.numberOfBrowsers)
 			        && Objects.equal(this.browserBuilder, that.browserBuilder)
 			        && Objects.equal(this.remoteHubUrl, that.remoteHubUrl)
-			        && Objects.equal(this.lang, that.lang);
+			        && Objects.equal(this.lang, that.lang)
+			        && Objects.equal(this.headless, that.headless);
 		}
 		return false;
 	}

--- a/core/src/test/java/com/crawljax/core/configuration/CrawljaxConfigurationBuilderTest.java
+++ b/core/src/test/java/com/crawljax/core/configuration/CrawljaxConfigurationBuilderTest.java
@@ -67,6 +67,19 @@ public class CrawljaxConfigurationBuilderTest {
 	}
 
 	@Test
+	public void shouldBeInHeadlessModeByDefault() throws Exception {
+		BrowserConfiguration browserConfiguration = testBuilder().build().getBrowserConfig();
+		assertThat(browserConfiguration.isHeadless(), is(true));
+	}
+
+	@Test
+	public void shouldSetNonHeadlessMode() throws Exception {
+		BrowserConfiguration browserConfiguration = testBuilder().build().getBrowserConfig();
+		browserConfiguration.setHeadless(false);
+		assertThat(browserConfiguration.isHeadless(), is(false));
+	}
+
+	@Test
 	public void whenSpecifyingBasicAuthTheUrlShouldBePreserved() {
 		String url = "https://example.com/test/?a=b#anchor";
 		CrawljaxConfiguration conf =


### PR DESCRIPTION
Change BrowserConfiguration to allow to set if the browsers should be
started in headless mode or not, also, set to start in headless mode by
default.
Change WebDriverBrowserBuilder to set the browsers as headless depending
on the new option.
Add tests to assert the new behaviour.