### PR TITLE
Handle unexpected alerts

### DIFF
--- a/core/src/main/java/com/crawljax/core/configuration/DefaultUnexpectedAlertHandler.java
+++ b/core/src/main/java/com/crawljax/core/configuration/DefaultUnexpectedAlertHandler.java
@@ -1,0 +1,29 @@
+package com.crawljax.core.configuration;
+
+import org.openqa.selenium.WebDriver;
+
+/**
+ * An {@link UnexpectedAlertHandler} that does not handle the alert and always retries the action.
+ * <p>
+ * Should be used only if the alerts are automatically handled (accepted or dismissed) by the
+ * selected {@code WebDriver}, for example, through the capability
+ * {@link org.openqa.selenium.remote.CapabilityType#UNHANDLED_PROMPT_BEHAVIOUR
+ * CapabilityType.UNHANDLED_PROMPT_BEHAVIOUR}.
+ * 
+ * @since 3.8
+ * @see #INSTANCE
+ */
+public class DefaultUnexpectedAlertHandler implements UnexpectedAlertHandler {
+
+	/**
+	 * The instance of {@code DefaultUnexpectedAlertHandler}.
+	 */
+	public static final DefaultUnexpectedAlertHandler INSTANCE =
+	        new DefaultUnexpectedAlertHandler();
+
+	@Override
+	public boolean handleAlert(WebDriver browser, String alertText) {
+		return true;
+	}
+
+}

--- a/core/src/main/java/com/crawljax/core/configuration/UnexpectedAlertHandler.java
+++ b/core/src/main/java/com/crawljax/core/configuration/UnexpectedAlertHandler.java
@@ -1,0 +1,32 @@
+package com.crawljax.core.configuration;
+
+import org.openqa.selenium.UnhandledAlertException;
+import org.openqa.selenium.WebDriver;
+
+/**
+ * A handler for unexpected/unhandled alerts ({@link UnhandledAlertException}).
+ * <p>
+ * Allows {@link com.crawljax.browser.WebDriverBackedEmbeddedBrowser WebDriverBackedEmbeddedBrowser}
+ * to handle unexpected/unhandled alerts when trying to execute browser actions, to continue or not
+ * with the normal crawling process.
+ * 
+ * @since 3.8
+ */
+@FunctionalInterface
+public interface UnexpectedAlertHandler {
+
+	/**
+	 * Handles the unexpected/unhandled alert and tells whether or not the browser action should be
+	 * retried.
+	 * <p>
+	 * Called when an {@code UnhandledAlertException} is caught after trying to execute a browser
+	 * action.
+	 * 
+	 * @param browser
+	 *            the browser that was executing the action.
+	 * @param alertText
+	 *            the text/message of the alert.
+	 * @return {@code true} if the action should be retried, {@code false} otherwise.
+	 */
+	boolean handleAlert(WebDriver browser, String alertText);
+}

--- a/core/src/test/java/com/crawljax/core/PopUpTest.java
+++ b/core/src/test/java/com/crawljax/core/PopUpTest.java
@@ -29,8 +29,8 @@ public class PopUpTest {
 		builder.crawlRules().waitAfterReloadUrl(100, TimeUnit.MILLISECONDS);
 		CrawljaxRunner runner = new CrawljaxRunner(builder.build());
 		CrawlSession session = runner.call();
-		assertThat(session.getStateFlowGraph(), hasEdges(2));
-		assertThat(session.getStateFlowGraph(), hasStates(3));
+		assertThat(session.getStateFlowGraph(), hasEdges(3));
+		assertThat(session.getStateFlowGraph(), hasStates(4));
 	}
 
 }

--- a/core/src/test/resources/site/popup/index.html
+++ b/core/src/test/resources/site/popup/index.html
@@ -35,6 +35,11 @@ function confirmation() {
 	}
 }
 
+alertfn = alert;
+function doCustomAlert() {
+	alertfn("custom alert");
+	doLoad("custom alert");
+}
 </script>
 
 
@@ -46,6 +51,7 @@ function confirmation() {
 	<li><a href="javascript:void(0)" onclick="doConfirm()">confirm me!</a></li>
 	<li><a href="javascript:void(0)" onclick="doLoad('some text')">load</a></li>
 	<li><a href="javascript:void(0)" onclick="confirmation()">leave?</a></li>
+	<li><a href="javascript:void(0)" onclick="doCustomAlert()">custom alert</a></li>
 </ul>
 <div id="content"></div>
 </body>


### PR DESCRIPTION
Change WebDriverBackedEmbeddedBrowser to handle the unexpected alerts
(when obtaining the source and the current URL) and retry the action
when that happens.
Add interface UnexpectedAlertHandler to allow customisation of the
behaviour when handling the unexpected alerts, for example, at the
moment Firefox requires (explicit) acceptance of the alerts while other
browsers don't (Chrome or PhantomJS). Also, add default implementation
which allows to continue with the actions and does not handle the
alerts.
Change WebDriverBrowserBuilder to set up capability to automatically
accept the unexpected alerts and to use a custom UnexpectedAlertHandler
with Firefox (as it does not yet support the new WebDriver capability).
Update tests (PopUpTest and "popup/index.html") to assert the new
behaviour.

Part of zaproxy/zaproxy#3412 - Ajax Spider closes the browser when an
alert box is triggered