### PR TITLE
Correct custom crawl scope test

### DIFF
--- a/core/src/test/java/com/crawljax/crawls/CrawlWithCustomScopeTest.java
+++ b/core/src/test/java/com/crawljax/crawls/CrawlWithCustomScopeTest.java
@@ -23,7 +23,8 @@ public class CrawlWithCustomScopeTest {
 
 	@Test
 	public void crawlsPagesOnlyInCustomScope() throws Exception {
-		CrawlScope crawlScope = url -> url.contains("in_scope") || url.endsWith("crawlscope/");
+		CrawlScope crawlScope =
+		        url -> url.contains("in_scope") || url.endsWith("crawlscope/index.html");
 		BaseCrawler baseCrawler = new BaseCrawler("crawlscope") {
 			@Override
 			public CrawljaxConfigurationBuilder newCrawlConfigurationBuilder() {


### PR DESCRIPTION
Update the URL checked in CrawlWithCustomScopeTest, with the update of
Jetty the check was no longer working properly since Jetty was no longer
serving the index.html file when accessing "crawlscope/", it now ends up
redirecting to "crawlscope/index.html".