### PR TITLE
Add JBrowserDriver

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -99,6 +99,18 @@
 		</dependency>
 
 		<dependency>
+			<groupId>com.machinepublishers</groupId>
+			<artifactId>jbrowserdriver</artifactId>
+			<version>0.17.9</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.seleniumhq.selenium</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-server</artifactId>
 			<version>${jetty.version}</version>

--- a/core/src/main/java/com/crawljax/browser/EmbeddedBrowser.java
+++ b/core/src/main/java/com/crawljax/browser/EmbeddedBrowser.java
@@ -21,7 +21,7 @@ public interface EmbeddedBrowser {
 	 * Browser types.
 	 */
 	public enum BrowserType {
-		FIREFOX, INTERNET_EXPLORER, CHROME, REMOTE, PHANTOMJS
+		FIREFOX, INTERNET_EXPLORER, CHROME, REMOTE, PHANTOMJS, JBD
 	}
 
 	/**

--- a/core/src/main/java/com/crawljax/browser/WebDriverBrowserBuilder.java
+++ b/core/src/main/java/com/crawljax/browser/WebDriverBrowserBuilder.java
@@ -10,6 +10,9 @@ import com.crawljax.core.configuration.UnexpectedAlertHandler;
 import com.crawljax.core.plugin.Plugins;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSortedSet;
+import com.machinepublishers.jbrowserdriver.JBrowserDriver;
+import com.machinepublishers.jbrowserdriver.ProxyConfig;
+import com.machinepublishers.jbrowserdriver.Settings;
 
 import org.openqa.selenium.NoAlertPresentException;
 import org.openqa.selenium.UnexpectedAlertBehaviour;
@@ -68,6 +71,10 @@ public class WebDriverBrowserBuilder implements Provider<EmbeddedBrowser> {
 					        WebDriverBackedEmbeddedBrowser.withDriver(
 					                new InternetExplorerDriver(),
 					                filterAttributes, crawlWaitEvent, crawlWaitReload);
+					break;
+				case JBD:
+					browser =
+					        newJBrowserDriver(filterAttributes, crawlWaitReload, crawlWaitEvent);
 					break;
 				case CHROME:
 					browser = newChromeBrowser(filterAttributes, crawlWaitReload, crawlWaitEvent);
@@ -157,6 +164,22 @@ public class WebDriverBrowserBuilder implements Provider<EmbeddedBrowser> {
 
 		return WebDriverBackedEmbeddedBrowser.withDriver(new ChromeDriver(optionsChrome), filterAttributes,
 		        crawlWaitEvent, crawlWaitReload);
+	}
+
+	private EmbeddedBrowser newJBrowserDriver(ImmutableSortedSet<String> filterAttributes,
+	        long crawlWaitReload, long crawlWaitEvent) {
+		Settings.Builder settingsBuilder = Settings.builder();
+		settingsBuilder.headless(configuration.getBrowserConfig().isHeadless());
+
+		ProxyConfiguration proxyConf = configuration.getProxyConfiguration();
+		if (proxyConf != null && proxyConf.getType() != ProxyType.NOTHING) {
+			settingsBuilder.proxy(new ProxyConfig(ProxyConfig.Type.HTTP, proxyConf.getHostname(),
+			        proxyConf.getPort()));
+		}
+
+		return WebDriverBackedEmbeddedBrowser.withDriver(
+		        new JBrowserDriver(settingsBuilder.build()),
+		        filterAttributes, crawlWaitEvent, crawlWaitReload);
 	}
 
 	private EmbeddedBrowser newPhantomJSDriver(ImmutableSortedSet<String> filterAttributes,

--- a/core/src/test/java/com/crawljax/browser/BrowserProvider.java
+++ b/core/src/test/java/com/crawljax/browser/BrowserProvider.java
@@ -16,6 +16,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Strings;
+import com.machinepublishers.jbrowserdriver.JBrowserDriver;
+import com.machinepublishers.jbrowserdriver.Settings;
 
 public class BrowserProvider extends ExternalResource {
 
@@ -49,6 +51,9 @@ public class BrowserProvider extends ExternalResource {
 	public RemoteWebDriver newBrowser() {
 		RemoteWebDriver driver;
 		switch (getBrowserType()) {
+		case JBD:
+			driver = new JBrowserDriver(Settings.builder().headless(true).build());
+			break;
 		case FIREFOX:
 			driver = newFirefoxDriver();
 			break;

--- a/core/src/test/java/com/crawljax/browser/WebDriverBackedEmbeddedBrowserNoCrashTest.java
+++ b/core/src/test/java/com/crawljax/browser/WebDriverBackedEmbeddedBrowserNoCrashTest.java
@@ -2,10 +2,13 @@
 
 package com.crawljax.browser;
 
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeThat;
 
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -22,6 +25,7 @@ import com.crawljax.test.BrowserTest;
 import com.crawljax.test.RunWithWebServer;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -43,6 +47,14 @@ public class WebDriverBackedEmbeddedBrowserNoCrashTest {
 	public final BrowserProvider provider = new BrowserProvider();
 
 	private EmbeddedBrowser browser;
+
+	@BeforeClass
+	public static void setupBeforeClass() {
+		// XXX JBrowserDriver hangs(?) if no URL is accessed before closing the browser
+		// which most of these tests do.
+		assumeThat("hangs(?) if no URL is accessed before closing the browser",
+		        BrowserProvider.getBrowserType(), is(not(EmbeddedBrowser.BrowserType.JBD)));
+	}
 
 	/**
 	 * Make a new Browser for every test.

--- a/core/src/test/java/com/crawljax/browser/WebDriverBackedEmbeddedBrowserTest.java
+++ b/core/src/test/java/com/crawljax/browser/WebDriverBackedEmbeddedBrowserTest.java
@@ -1,7 +1,10 @@
 package com.crawljax.browser;
 
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeThat;
 
 import java.io.File;
 import java.io.IOException;
@@ -31,6 +34,10 @@ public class WebDriverBackedEmbeddedBrowserTest {
 
 	@Test
 	public void testGetDocument() throws Exception {
+		// XXX JBrowserDriver issue: https://github.com/MachinePublishers/jBrowserDriver/issues/235
+		assumeThat("iframe tests lead to hangs/loops", BrowserProvider.getBrowserType(),
+		        is(not(EmbeddedBrowser.BrowserType.JBD)));
+
 		WebDriverBackedEmbeddedBrowser browser = WebDriverBackedEmbeddedBrowser
 				.withDriver(provider.newBrowser(),
 						ImmutableSortedSet.<String> of(), 100, 100);

--- a/core/src/test/java/com/crawljax/core/CandidateElementExtractorTest.java
+++ b/core/src/test/java/com/crawljax/core/CandidateElementExtractorTest.java
@@ -2,9 +2,11 @@ package com.crawljax.core;
 
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assume.assumeThat;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -25,6 +27,7 @@ import com.crawljax.forms.FormHandler;
 import com.crawljax.test.BrowserTest;
 import com.crawljax.test.RunWithWebServer;
 import com.google.common.io.Resources;
+
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -112,6 +115,10 @@ public class CandidateElementExtractorTest {
 
 	@Test
 	public void testExtractIframeContents() throws Exception {
+		// XXX JBrowserDriver issue: https://github.com/MachinePublishers/jBrowserDriver/issues/235
+		assumeThat("iframe tests lead to hangs/loops", BrowserProvider.getBrowserType(),
+		        is(not(EmbeddedBrowser.BrowserType.JBD)));
+
 		RunWithWebServer server = new RunWithWebServer("/site");
 		server.before();
 		CrawljaxConfigurationBuilder builder = CrawljaxConfiguration

--- a/core/src/test/java/com/crawljax/core/IFrameTest.java
+++ b/core/src/test/java/com/crawljax/core/IFrameTest.java
@@ -4,15 +4,21 @@ package com.crawljax.core;
 
 import static com.crawljax.browser.matchers.StateFlowGraphMatchers.hasEdges;
 import static com.crawljax.browser.matchers.StateFlowGraphMatchers.hasStates;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assume.assumeThat;
 
 import java.util.concurrent.TimeUnit;
 
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+import com.crawljax.browser.BrowserProvider;
+import com.crawljax.browser.EmbeddedBrowser;
 import com.crawljax.core.configuration.CrawljaxConfiguration;
 import com.crawljax.core.configuration.CrawljaxConfiguration.CrawljaxConfigurationBuilder;
 import com.crawljax.test.BrowserTest;
@@ -28,6 +34,13 @@ public class IFrameTest {
 
 	@ClassRule
 	public static final RunWithWebServer WEB_SERVER = new RunWithWebServer("/site");
+
+	@BeforeClass
+	public static void setUpBeforeClass() {
+		// XXX JBrowserDriver issue: https://github.com/MachinePublishers/jBrowserDriver/issues/235
+		assumeThat("iframe tests lead to hangs/loops", BrowserProvider.getBrowserType(),
+		        is(not(EmbeddedBrowser.BrowserType.JBD)));
+	}
 
 	protected CrawljaxConfigurationBuilder setupConfig() {
 		CrawljaxConfigurationBuilder builder = WEB_SERVER.newConfigBuilder("iframe");

--- a/core/src/test/java/com/crawljax/core/PassBasicHttpAuthTest.java
+++ b/core/src/test/java/com/crawljax/core/PassBasicHttpAuthTest.java
@@ -3,6 +3,7 @@ package com.crawljax.core;
 import static com.crawljax.browser.matchers.StateFlowGraphMatchers.hasStates;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
+import static org.hamcrest.core.AnyOf.anyOf;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assume.assumeThat;
 
@@ -17,6 +18,7 @@ import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.security.Constraint;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -36,6 +38,17 @@ public class PassBasicHttpAuthTest {
 
 	private Server server;
 	private int port;
+
+	@BeforeClass
+	public static void setupBeforeClass() {
+		// XXX PhantomJS issue: https://github.com/ariya/phantomjs/issues/12665
+		// XXX JBrowserDriver issue:
+		// https://github.com/MachinePublishers/jBrowserDriver/issues/132#issuecomment-259491450
+		assumeThat("URLs with userinfo are not correctly processed",
+		        BrowserProvider.getBrowserType(),
+		        not(anyOf(is(EmbeddedBrowser.BrowserType.PHANTOMJS),
+		                is(EmbeddedBrowser.BrowserType.JBD))));
+	}
 
 	@Before
 	public void setup() throws Exception {
@@ -75,11 +88,6 @@ public class PassBasicHttpAuthTest {
 
 	@Test
 	public void testProvidedCredentialsAreUsedInBasicAuth() throws Exception {
-		// XXX PhantomJS issue: https://github.com/ariya/phantomjs/issues/12665
-		assumeThat("URLs with userinfo are not correctly processed",
-		        BrowserProvider.getBrowserType(),
-		        is(not(EmbeddedBrowser.BrowserType.PHANTOMJS)));
-
 		String url = "http://localhost:" + port + "/infinite.html";
 		CrawljaxConfigurationBuilder builder =
 		        CrawljaxConfiguration.builderFor(url);

--- a/core/src/test/java/com/crawljax/core/largetests/LargeJBrowserDriverTest.java
+++ b/core/src/test/java/com/crawljax/core/largetests/LargeJBrowserDriverTest.java
@@ -1,0 +1,27 @@
+package com.crawljax.core.largetests;
+
+import org.junit.experimental.categories.Category;
+
+import com.crawljax.browser.EmbeddedBrowser.BrowserType;
+import com.crawljax.core.configuration.BrowserConfiguration;
+import com.crawljax.test.BrowserTest;
+
+@Category(BrowserTest.class)
+public class LargeJBrowserDriverTest extends LargeTestBase {
+
+	@Override
+	BrowserConfiguration getBrowserConfiguration() {
+		return new BrowserConfiguration(BrowserType.JBD);
+	}
+
+	@Override
+	long getTimeOutAfterReloadUrl() {
+		return 200;
+	}
+
+	@Override
+	long getTimeOutAfterEvent() {
+		return 200;
+	}
+
+}


### PR DESCRIPTION
Allow to choose JBrowserDriver as one of the browsers to run Crawljax
with.
Change some tests to not run with JBrowserDriver, causes hangs.

Related to zaproxy/zaproxy#3795 - JBrowserDriver add-on