### PR TITLE
Disable tests "failing" with Firefox (bug 1332122)

### DIFF
--- a/core/src/test/java/com/crawljax/browser/WebDriverBackedEmbeddedBrowserNoCrashTest.java
+++ b/core/src/test/java/com/crawljax/browser/WebDriverBackedEmbeddedBrowserNoCrashTest.java
@@ -130,6 +130,10 @@ public class WebDriverBackedEmbeddedBrowserNoCrashTest {
 	 */
 	@Test
 	public final void testGetDom() throws CrawljaxException, URISyntaxException {
+		// XXX Firefox issue: https://bugzilla.mozilla.org/show_bug.cgi?id=1332122
+		assumeThat("file:// leads to \"hangs\"", BrowserProvider.getBrowserType(),
+		        is(not(EmbeddedBrowser.BrowserType.FIREFOX)));
+
 		URL index = WebDriverBackedEmbeddedBrowserTest.class.getResource("/site/simple.html");
 		browser.goToUrl(index.toURI());
 		browser.getStrippedDom();

--- a/core/src/test/java/com/crawljax/core/CandidateElementExtractorTest.java
+++ b/core/src/test/java/com/crawljax/core/CandidateElementExtractorTest.java
@@ -144,6 +144,10 @@ public class CandidateElementExtractorTest {
 
 	@Test
 	public void whenNoFollowExternalUrlDoNotFollow() throws IOException, URISyntaxException {
+		// XXX Firefox issue: https://bugzilla.mozilla.org/show_bug.cgi?id=1332122
+		assumeThat("file:// leads to \"hangs\"", BrowserProvider.getBrowserType(),
+		        is(not(EmbeddedBrowser.BrowserType.FIREFOX)));
+
 		CrawljaxConfigurationBuilder builder =
 		        CrawljaxConfiguration.builderFor("http://example.com");
 		builder.crawlRules().click("a");
@@ -158,6 +162,10 @@ public class CandidateElementExtractorTest {
 
 	@Test
 	public void whenFollowExternalUrlDoFollow() throws IOException, URISyntaxException {
+		// XXX Firefox issue: https://bugzilla.mozilla.org/show_bug.cgi?id=1332122
+		assumeThat("file:// leads to \"hangs\"", BrowserProvider.getBrowserType(),
+		        is(not(EmbeddedBrowser.BrowserType.FIREFOX)));
+
 		CrawljaxConfigurationBuilder builder =
 		        CrawljaxConfiguration.builderFor("http://example.com");
 		builder.crawlRules().click("a");

--- a/core/src/test/java/com/crawljax/util/DomUtilsBrowserTest.java
+++ b/core/src/test/java/com/crawljax/util/DomUtilsBrowserTest.java
@@ -1,6 +1,9 @@
 package com.crawljax.util;
 
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assume.assumeThat;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -10,6 +13,7 @@ import com.crawljax.browser.BrowserProvider;
 import com.crawljax.browser.EmbeddedBrowser;
 import com.crawljax.test.BrowserTest;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -27,6 +31,13 @@ public class DomUtilsBrowserTest {
 	public BrowserProvider provider = new BrowserProvider();
 
 	private EmbeddedBrowser browser;
+
+	@BeforeClass
+	public static void setUpBeforeClass() {
+		// XXX Firefox issue: https://bugzilla.mozilla.org/show_bug.cgi?id=1332122
+		assumeThat("file:// leads to \"hangs\"", BrowserProvider.getBrowserType(),
+		        is(not(EmbeddedBrowser.BrowserType.FIREFOX)));
+	}
 
 	@Before
 	public void before() throws URISyntaxException {


### PR DESCRIPTION
Disable tests "failing" (tests do not terminate) with Firefox because of
bug 1332122:
 Navigating to file:// URLs times out in Marionette