### PR TITLE
Use new Timeout constructors

### DIFF
--- a/core/src/test/java/com/crawljax/core/largetests/LargeTestBase.java
+++ b/core/src/test/java/com/crawljax/core/largetests/LargeTestBase.java
@@ -112,7 +112,7 @@ public abstract class LargeTestBase {
 	public static final RunWithWebServer WEB_SERVER = new RunWithWebServer("/site");
 
 	@Rule
-	public final Timeout timeout = new Timeout((int) TimeUnit.MINUTES.toMillis(15));
+	public final Timeout timeout = new Timeout(15, TimeUnit.MINUTES);
 
 	@Before
 	public void setup() throws Exception {

--- a/web/src/test/java/com/crawljax/web/jaxrs/StandardFunctionsFlowTest.java
+++ b/web/src/test/java/com/crawljax/web/jaxrs/StandardFunctionsFlowTest.java
@@ -51,7 +51,7 @@ public class StandardFunctionsFlowTest {
 	        "https://raw.githubusercontent.com/crawljax/crawljax/master/web/src/test/resources/dummy-plugin.jar";
 
 	@Rule
-	public TestRule globalTimeout = new Timeout(120 * 1000);
+	public TestRule globalTimeout = new Timeout(120, TimeUnit.SECONDS);
 
 	@ClassRule
 	public static final CrawljaxServerResource SERVER = new CrawljaxServerResource();


### PR DESCRIPTION
Change LargeTestBase and StandardFunctionsFlowTest to use the Timeout
constructors with TimeUnit.