### PR TITLE
Use Utils.assumeBinary in ChromeProxyConfig

### DIFF
--- a/core/src/test/java/com/crawljax/browser/ChromeProxyConfig.java
+++ b/core/src/test/java/com/crawljax/browser/ChromeProxyConfig.java
@@ -1,10 +1,7 @@
 package com.crawljax.browser;
 
 import static com.crawljax.browser.matchers.StateFlowGraphMatchers.hasStates;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsNull.notNullValue;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assume.assumeThat;
 
 import org.eclipse.jetty.util.resource.Resource;
 import org.junit.Test;
@@ -16,13 +13,15 @@ import com.crawljax.core.configuration.BrowserConfiguration;
 import com.crawljax.core.configuration.CrawljaxConfiguration.CrawljaxConfigurationBuilder;
 import com.crawljax.test.BaseCrawler;
 import com.crawljax.test.BrowserTest;
+import com.crawljax.test.Utils;
 
 @Category(BrowserTest.class)
 public class ChromeProxyConfig {
 
 	@Test
-	public void chromeProxyConfig() {
-		assumeThat(System.getProperty("webdriver.chrome.driver"), is(notNullValue()));
+	public void chromeProxyConfig() throws Exception {
+		Utils.assumeBinary("webdriver.chrome.driver", "chromedriver");
+
 		CrawlSession crawl =
 		        new BaseCrawler(Resource.newClassPathResource("/site"),
 		                "simplelink/simplelink.html") {


### PR DESCRIPTION
Change ChromeProxyConfig to Utils.assumeBinary to check if ChromeDriver
is available, instead of checking just the system property.