### PR TITLE
Update Selenium and JBrowserDriver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,8 @@ language: java
 sudo: false
 
 before_install:
-  - wget https://github.com/mozilla/geckodriver/releases/download/v0.18.0/geckodriver-v0.18.0-linux64.tar.gz
   - mkdir geckodriver
-  - tar -xzf geckodriver-v0.18.0-linux64.tar.gz -C geckodriver
+  - GECKODRIVER_VER="0.19.1"; wget -qO - https://github.com/mozilla/geckodriver/releases/download/v$GECKODRIVER_VER/geckodriver-v$GECKODRIVER_VER-linux64.tar.gz | tar xz -C geckodriver
   - export PATH=$PATH:$PWD/geckodriver
 
 install: cd core && mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -101,7 +101,7 @@
 		<dependency>
 			<groupId>com.machinepublishers</groupId>
 			<artifactId>jbrowserdriver</artifactId>
-			<version>0.17.9</version>
+			<version>0.17.11</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.seleniumhq.selenium</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<slf4j.version>1.7.25</slf4j.version>
 		<logback.version>1.2.3</logback.version>
-		<selenium.version>3.5.3</selenium.version>
+		<selenium.version>3.7.1</selenium.version>
 		<!-- Guava version used by Crawljax needs to be compatible with the one used by Selenium, otherwise JAR hell. -->
 		<guava.version>23.0</guava.version>
 		<jetty.version>9.4.6.v20170531</jetty.version>


### PR DESCRIPTION
Update Selenium to 3.7.1 and JBrowserDriver to 0.17.11 (required by the
newer Selenium version).
Change Travis CI build configuration file to use newer geckodriver
version 0.19.1. Also, tweak the command to specify its version just
once.

Related to zaproxy/zaproxy#3830 - Update Selenium library
Related to zaproxy/zaproxy#3890 - Update geckodriver