### PR TITLE
Use Firefox 57 in Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ jdk:
   - oraclejdk8
 
 addons:
-  firefox: latest
+  firefox: "57.0.4"


### PR DESCRIPTION
Change Travis CI configuration file to use Firefox 57.0.4, which works
as expected. Newer Firefox versions (>=58) fail some of the tests.