### PR TITLE
Sign artifacts by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_install:
   - GECKODRIVER_VER="0.20.1"; wget -qO - https://github.com/mozilla/geckodriver/releases/download/v$GECKODRIVER_VER/geckodriver-v$GECKODRIVER_VER-linux64.tar.gz | tar xz -C geckodriver
   - export PATH=$PATH:$PWD/geckodriver
 
-install: cd core && mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+install: cd core && mvn install -DskipTests=true -Dmaven.javadoc.skip=true -Dgpg.skip=true -B -V
 script: mvn test -B -Pintegrationtests -Dtest.browser=FIREFOX
 
 jdk:

--- a/pom.xml
+++ b/pom.xml
@@ -255,6 +255,20 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-gpg-plugin</artifactId>
+				<version>1.6</version>
+				<executions>
+					<execution>
+						<id>sign-artifacts</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>sign</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
Change parent POM to have the artifacts (POMs, JARs) signed by default.
Tweak Travis CI configuration file to skip the signing.