### PR TITLE
Isolate large browser tests

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -101,7 +101,7 @@
 		<dependency>
 			<groupId>com.machinepublishers</groupId>
 			<artifactId>jbrowserdriver</artifactId>
-			<version>0.17.11</version>
+			<version>1.0.0-RC1</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.seleniumhq.selenium</groupId>

--- a/core/src/test/java/com/crawljax/core/largetests/LargeChromeTest.java
+++ b/core/src/test/java/com/crawljax/core/largetests/LargeChromeTest.java
@@ -1,6 +1,7 @@
 package com.crawljax.core.largetests;
 
 import com.crawljax.browser.EmbeddedBrowser.BrowserType;
+import com.crawljax.core.CrawlSession;
 import com.crawljax.core.configuration.BrowserConfiguration;
 import com.crawljax.test.BrowserTest;
 import com.crawljax.test.Utils;
@@ -11,23 +12,17 @@ import org.junit.experimental.categories.Category;
 @Category(BrowserTest.class)
 public class LargeChromeTest extends LargeTestBase {
 
+	private static CrawlSession session;
+
 	@BeforeClass
 	public static void setUpBeforeClass() throws Exception {
 		Utils.assumeBinary("webdriver.chrome.driver", "chromedriver");
+
+		session = setup(new BrowserConfiguration(BrowserType.CHROME), 100, 100);
 	}
 
 	@Override
-	BrowserConfiguration getBrowserConfiguration() {
-		return new BrowserConfiguration(BrowserType.CHROME);
-	}
-
-	@Override
-	long getTimeOutAfterReloadUrl() {
-		return 100;
-	}
-
-	@Override
-	long getTimeOutAfterEvent() {
-		return 100;
+	protected CrawlSession getSession() {
+		return session;
 	}
 }

--- a/core/src/test/java/com/crawljax/core/largetests/LargeFirefoxTest.java
+++ b/core/src/test/java/com/crawljax/core/largetests/LargeFirefoxTest.java
@@ -4,6 +4,7 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
 import com.crawljax.browser.EmbeddedBrowser.BrowserType;
+import com.crawljax.core.CrawlSession;
 import com.crawljax.core.configuration.BrowserConfiguration;
 import com.crawljax.test.BrowserTest;
 import com.crawljax.test.Utils;
@@ -11,24 +12,17 @@ import com.crawljax.test.Utils;
 @Category(BrowserTest.class)
 public class LargeFirefoxTest extends LargeTestBase {
 
+	private static CrawlSession session;
+
 	@BeforeClass
 	public static void setUpBeforeClass() throws Exception {
 		Utils.assumeBinary("webdriver.gecko.driver", "geckodriver");
+
+		session = setup(new BrowserConfiguration(BrowserType.FIREFOX, 1), 200, 200);
 	}
 
 	@Override
-	BrowserConfiguration getBrowserConfiguration() {
-		return new BrowserConfiguration(BrowserType.FIREFOX, 1);
+	protected CrawlSession getSession() {
+		return session;
 	}
-
-	@Override
-	long getTimeOutAfterReloadUrl() {
-		return 200;
-	}
-
-	@Override
-	long getTimeOutAfterEvent() {
-		return 200;
-	}
-
 }

--- a/core/src/test/java/com/crawljax/core/largetests/LargeIETest.java
+++ b/core/src/test/java/com/crawljax/core/largetests/LargeIETest.java
@@ -7,31 +7,24 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
 import com.crawljax.browser.EmbeddedBrowser.BrowserType;
-import com.crawljax.core.CrawljaxException;
+import com.crawljax.core.CrawlSession;
 import com.crawljax.core.configuration.BrowserConfiguration;
 import com.crawljax.test.BrowserTest;
 
 @Category(BrowserTest.class)
 public class LargeIETest extends LargeTestBase {
 
+	private static CrawlSession session;
+
 	@BeforeClass
-	public static void setUpBeforeClass() throws CrawljaxException {
+	public static void setUpBeforeClass() throws Exception {
 		assumeThat(System.getProperty("os.name").toLowerCase(), containsString("windows"));
+
+		session = setup(new BrowserConfiguration(BrowserType.INTERNET_EXPLORER), 400, 400);
 	}
 
 	@Override
-	BrowserConfiguration getBrowserConfiguration() {
-		return new BrowserConfiguration(BrowserType.INTERNET_EXPLORER);
+	protected CrawlSession getSession() {
+		return session;
 	}
-
-	@Override
-	long getTimeOutAfterReloadUrl() {
-		return 400;
-	}
-
-	@Override
-	long getTimeOutAfterEvent() {
-		return 800;
-	}
-
 }

--- a/core/src/test/java/com/crawljax/core/largetests/LargeJBrowserDriverTest.java
+++ b/core/src/test/java/com/crawljax/core/largetests/LargeJBrowserDriverTest.java
@@ -1,27 +1,26 @@
 package com.crawljax.core.largetests;
 
+import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
 import com.crawljax.browser.EmbeddedBrowser.BrowserType;
+import com.crawljax.core.CrawlSession;
 import com.crawljax.core.configuration.BrowserConfiguration;
 import com.crawljax.test.BrowserTest;
 
 @Category(BrowserTest.class)
 public class LargeJBrowserDriverTest extends LargeTestBase {
 
-	@Override
-	BrowserConfiguration getBrowserConfiguration() {
-		return new BrowserConfiguration(BrowserType.JBD);
+	private static CrawlSession session;
+
+	@BeforeClass
+	public static void setUpBeforeClass() throws Exception {
+		session = setup(new BrowserConfiguration(BrowserType.JBD), 200, 200);
 	}
 
 	@Override
-	long getTimeOutAfterReloadUrl() {
-		return 200;
-	}
-
-	@Override
-	long getTimeOutAfterEvent() {
-		return 200;
+	protected CrawlSession getSession() {
+		return session;
 	}
 
 }

--- a/core/src/test/java/com/crawljax/core/largetests/LargePhantomJSTest.java
+++ b/core/src/test/java/com/crawljax/core/largetests/LargePhantomJSTest.java
@@ -1,6 +1,7 @@
 package com.crawljax.core.largetests;
 
 import com.crawljax.browser.EmbeddedBrowser.BrowserType;
+import com.crawljax.core.CrawlSession;
 import com.crawljax.core.configuration.BrowserConfiguration;
 import com.crawljax.test.BrowserTest;
 import com.crawljax.test.Utils;
@@ -11,24 +12,17 @@ import org.junit.experimental.categories.Category;
 @Category(BrowserTest.class)
 public class LargePhantomJSTest extends LargeTestBase {
 
+	private static CrawlSession session;
+
 	@BeforeClass
 	public static void setUpBeforeClass() throws Exception {
 		Utils.assumeBinary("phantomjs.binary.path", "phantomjs");
+
+		session = setup(new BrowserConfiguration(BrowserType.PHANTOMJS, 1), 200, 200);
 	}
 
 	@Override
-	BrowserConfiguration getBrowserConfiguration() {
-		return new BrowserConfiguration(BrowserType.PHANTOMJS, 1);
+	protected CrawlSession getSession() {
+		return session;
 	}
-
-	@Override
-	long getTimeOutAfterReloadUrl() {
-		return 200;
-	}
-
-	@Override
-	long getTimeOutAfterEvent() {
-		return 200;
-	}
-
 }


### PR DESCRIPTION
Use a class variable for each browser instead of one in LargeTestBase
to ensure that each browser is tested and that the results of one
browser don't affect the others.
Update JBrowserDriver for compatibility with Selenium version already in
use.