### PR TITLE
Do not run JBD tests if needed classes not present

### DIFF
--- a/core/src/test/java/com/crawljax/core/largetests/LargeJBrowserDriverTest.java
+++ b/core/src/test/java/com/crawljax/core/largetests/LargeJBrowserDriverTest.java
@@ -1,5 +1,8 @@
 package com.crawljax.core.largetests;
 
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assume.assumeThat;
+
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
@@ -15,7 +18,17 @@ public class LargeJBrowserDriverTest extends LargeTestBase {
 
 	@BeforeClass
 	public static void setUpBeforeClass() throws Exception {
+		assumeThat("not able to run without some com.sun classes", hasComSunClasses(), is(true));
 		session = setup(new BrowserConfiguration(BrowserType.JBD), 200, 200);
+	}
+
+	private static boolean hasComSunClasses() {
+		try {
+			Class.forName("com.sun.webkit.network.CookieManager");
+			return true;
+		} catch (ClassNotFoundException e) {
+		}
+		return false;
 	}
 
 	@Override


### PR DESCRIPTION
Change LargeJBrowserDriverTest to skip the tests if the com.sun class
CookieManager (one of the required classes) is not present, the tests
would fail (e.g. IBM JDK).