### PR TITLE
Address Java 9 (and above) related issues in core

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ script: mvn test -B -Pintegrationtests -Dtest.browser=FIREFOX
 
 jdk:
   - oraclejdk8
+  - oraclejdk9
 
 addons:
   firefox: "57.0.4"

--- a/core/src/main/java/com/crawljax/util/DomUtils.java
+++ b/core/src/main/java/com/crawljax/util/DomUtils.java
@@ -244,6 +244,7 @@ public final class DomUtils {
 			TransformerFactory factory = TransformerFactory.newInstance();
 			Transformer transformer = factory.newTransformer();
 			transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+			transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "0");
 			transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION,
 					"yes");
 			transformer.setOutputProperty(OutputKeys.METHOD, "html");

--- a/core/src/main/java/com/crawljax/util/HtmlNamespace.java
+++ b/core/src/main/java/com/crawljax/util/HtmlNamespace.java
@@ -49,7 +49,7 @@ public class HtmlNamespace implements NamespaceContext {
 	 * @return TODO: DOCUMENT ME!
 	 */
 	@Override
-	public Iterator<?> getPrefixes(String uri) {
+	public Iterator<String> getPrefixes(String uri) {
 		throw new UnsupportedOperationException();
 	}
 }


### PR DESCRIPTION
Change DomUtils to not indent the string representation of the DOM, to
keep the same behaviour as before.
Change HtmlNamespace.getPrefixes return type to cope with type change.
Change .travis.yml to also run the build with Java 9.