### PR TITLE
Add Java 10 to Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ script: mvn test -B -Pintegrationtests -Dtest.browser=FIREFOX
 jdk:
   - oraclejdk8
   - oraclejdk9
+  - oraclejdk10
 
 addons:
   firefox: "57.0.4"


### PR DESCRIPTION
Change .travis.yml to also run the build with Java 10.