### PR TITLE
Remove empty style attributes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ jdk:
   - oraclejdk10
 
 addons:
-  firefox: "57.0.4"
+  firefox: "60.0.2"

--- a/core/src/main/java/com/crawljax/browser/WebDriverBackedEmbeddedBrowser.java
+++ b/core/src/main/java/com/crawljax/browser/WebDriverBackedEmbeddedBrowser.java
@@ -621,6 +621,13 @@ public final class WebDriverBackedEmbeddedBrowser implements EmbeddedBrowser {
 			Matcher m = p.matcher(html);
 			filteredHtml = m.replaceAll("");
 		}
+
+		// XXX Stop removing empty style attributes once Marionette issue is fixed:
+		// https://bugzilla.mozilla.org/show_bug.cgi?id=1448340
+		// In new Firefox versions (>= 59) Marionette adds an empty style attribute to clicked
+		// elements which incorrectly causes new crawling states.
+		filteredHtml = filteredHtml.replaceAll("(?i)\\sstyle=\"\"", "");
+
 		return filteredHtml;
 	}
 


### PR DESCRIPTION
Change WebDriverBackedEmbeddedBrowser to remove empty style attributes
when filtering attributes to workaround Marionette issue:
https://bugzilla.mozilla.org/show_bug.cgi?id=1448340
In newer Firefox versions (>= 59) Marionette adds an empty style
attribute to clicked elements which incorrectly causes new crawling
states.
Change Travis CI configuration file to use latest version of Firefox
(60.0.2), which now works as expected.