### PR TITLE
Don't rely on thread's interrupted state to stop

### DIFF
--- a/core/src/test/java/com/crawljax/core/CrawlerTest.java
+++ b/core/src/test/java/com/crawljax/core/CrawlerTest.java
@@ -126,7 +126,8 @@ public class CrawlerTest {
 		        new Crawler(context, config,
 		                stateComparator,
 		                candidateActionCache, formHandlerFactory, waitConditionChecker,
-		                elementExtractor, graphProvider, plugins, new DefaultStateVertexFactory());
+		                elementExtractor, graphProvider, plugins, new DefaultStateVertexFactory(),
+		                exitNotifier);
 
 		setupStateFlowGraph();
 	}


### PR DESCRIPTION
Change Crawler to use ExitNotifier instead of relying on the thread's
interrupted state to stop crawling, the latter might be cleared after
using the WebDriver (i.e. square/okhttp#3945) which would break the
Crawler as it no longer sees that it should stop.

Changing Selenium's default HTTP implementation to Apache HttpComponents
Client would also address this issue (since the interrupted status is
kept) but this change seems more reliable.