### PR TITLE
Update Firefox and geckodriver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,15 @@ language: java
 
 before_install:
   - mkdir geckodriver
-  - GECKODRIVER_VER="0.20.1"; wget -qO - https://github.com/mozilla/geckodriver/releases/download/v$GECKODRIVER_VER/geckodriver-v$GECKODRIVER_VER-linux64.tar.gz | tar xz -C geckodriver
+  - GECKODRIVER_VER="0.26.0"; wget -qO - https://github.com/mozilla/geckodriver/releases/download/v$GECKODRIVER_VER/geckodriver-v$GECKODRIVER_VER-linux64.tar.gz | tar xz -C geckodriver
   - export PATH=$PATH:$PWD/geckodriver
 
 install: cd core && mvn install -DskipTests=true -Dmaven.javadoc.skip=true -Dgpg.skip=true -B -V
 script: mvn test -B -Pintegrationtests -Dtest.browser=FIREFOX
 
 jdk:
-  - oraclejdk8
+  - openjdk8
   - openjdk11
 
 addons:
-  firefox: "60.0.2"
+  firefox: "75.0"


### PR DESCRIPTION
Update Firefox (75.0) and geckodriver (0.26.0) to latest versions.