### PR TITLE
Add Java 11 to Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,7 @@ script: mvn test -B -Pintegrationtests -Dtest.browser=FIREFOX
 
 jdk:
   - oraclejdk8
-  - oraclejdk9
-  - oraclejdk10
+  - openjdk11
 
 addons:
   firefox: "60.0.2"

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -43,6 +43,11 @@
 		</dependency>
 
 
+		<dependency>
+			<groupId>org.glassfish.jaxb</groupId>
+			<artifactId>jaxb-runtime</artifactId>
+			<version>2.4.0-b180725.0644</version>
+		</dependency>
 
 		<dependency>
 			<groupId>net.sf.jgrapht</groupId>


### PR DESCRIPTION
Change .travis.yml to run the build with Java 11, also, remove Java 9
and 10 as they will be soon superseded by Java 11.
Add dependency for JAXB (no longer included, JEP 320).