### PR TITLE
fix multiple fill in problem

### DIFF
--- a/core/src/main/java/com/crawljax/forms/FormHandler.java
+++ b/core/src/main/java/com/crawljax/forms/FormHandler.java
@@ -117,7 +117,8 @@ public class FormHandler {
         if (null == text || text.length() == 0) {
             return;
         }
-        WebElement inputElement = browser.getWebElement(input.getIdentification());
+		WebElement inputElement = browser.getWebElement(input.getIdentification());
+		inputElement.clear();
         inputElement.sendKeys(text);
     }
 


### PR DESCRIPTION
Hello!! Recently I'm using crawljax, and I discovered that when using __Form Field Input Values__ feature of crawljax web interface to automatically fill in a value for an input (e.g., text), sometimes crawljax will fill in the value for multiple times. So, I try to fix this bug.

![](https://i.imgur.com/Bx2Lyr9.png)

I found that Crawljax doesn't clear the input when a new action doesn't change the URL. For example, in the following figure, Crawljax first enters "test@gmail.com" into the __Employee email__ input and then excutes an action A1. Suppose the action A1 (e.g., a hidden button) doesn't change the URL. Since the URL doesn't change, the page is not refreshed and the input remains the same ("test@gmail.com"). Later when crawljax trys to click the login button, it will enter "test@gmail.com" again into the same input. The input becomes "test@gmail.comtest@gmail.com", which is not the intended input value assigned by the __Form Field Input Values__. Thus, crawljax will not be able to login the page successfully.

![](https://i.imgur.com/WlERxi8.png)

The problem can be fixed by adding a new line of code at line 121, in core/src/../forms/FormHandler.java, which clears an input element before an action is to be executed.

```java
120    WebElement inputElement = browser.getWebElement(input.getIdentification());
121    inputElement.clear();
122    inputElement.sendKeys(text);
```
So, I'm sending this PR. Could you please accept this request? Thanks!
I'm looking forward to your responce.