### PR TITLE
Do not skip tests with file scheme

### DIFF
--- a/core/src/test/java/com/crawljax/browser/WebDriverBackedEmbeddedBrowserNoCrashTest.java
+++ b/core/src/test/java/com/crawljax/browser/WebDriverBackedEmbeddedBrowserNoCrashTest.java
@@ -130,10 +130,6 @@ public class WebDriverBackedEmbeddedBrowserNoCrashTest {
 	 */
 	@Test
 	public final void testGetDom() throws CrawljaxException, URISyntaxException {
-		// XXX Firefox issue: https://bugzilla.mozilla.org/show_bug.cgi?id=1332122
-		assumeThat("file:// leads to \"hangs\"", BrowserProvider.getBrowserType(),
-		        is(not(EmbeddedBrowser.BrowserType.FIREFOX)));
-
 		URL index = WebDriverBackedEmbeddedBrowserTest.class.getResource("/site/simple.html");
 		browser.goToUrl(index.toURI());
 		browser.getStrippedDom();

--- a/core/src/test/java/com/crawljax/core/CandidateElementExtractorTest.java
+++ b/core/src/test/java/com/crawljax/core/CandidateElementExtractorTest.java
@@ -146,10 +146,6 @@ public class CandidateElementExtractorTest {
 
 	@Test
 	public void whenNoFollowExternalUrlDoNotFollow() throws IOException, URISyntaxException {
-		// XXX Firefox issue: https://bugzilla.mozilla.org/show_bug.cgi?id=1332122
-		assumeThat("file:// leads to \"hangs\"", BrowserProvider.getBrowserType(),
-		        is(not(EmbeddedBrowser.BrowserType.FIREFOX)));
-
 		CrawljaxConfigurationBuilder builder =
 		        CrawljaxConfiguration.builderFor("http://example.com");
 		builder.crawlRules().click("a");
@@ -164,10 +160,6 @@ public class CandidateElementExtractorTest {
 
 	@Test
 	public void whenFollowExternalUrlDoFollow() throws IOException, URISyntaxException {
-		// XXX Firefox issue: https://bugzilla.mozilla.org/show_bug.cgi?id=1332122
-		assumeThat("file:// leads to \"hangs\"", BrowserProvider.getBrowserType(),
-		        is(not(EmbeddedBrowser.BrowserType.FIREFOX)));
-
 		CrawljaxConfigurationBuilder builder =
 		        CrawljaxConfiguration.builderFor("http://example.com");
 		builder.crawlRules().click("a");

--- a/core/src/test/java/com/crawljax/util/DomUtilsBrowserTest.java
+++ b/core/src/test/java/com/crawljax/util/DomUtilsBrowserTest.java
@@ -1,9 +1,6 @@
 package com.crawljax.util;
 
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assume.assumeThat;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -13,7 +10,6 @@ import com.crawljax.browser.BrowserProvider;
 import com.crawljax.browser.EmbeddedBrowser;
 import com.crawljax.test.BrowserTest;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -31,13 +27,6 @@ public class DomUtilsBrowserTest {
 	public BrowserProvider provider = new BrowserProvider();
 
 	private EmbeddedBrowser browser;
-
-	@BeforeClass
-	public static void setUpBeforeClass() {
-		// XXX Firefox issue: https://bugzilla.mozilla.org/show_bug.cgi?id=1332122
-		assumeThat("file:// leads to \"hangs\"", BrowserProvider.getBrowserType(),
-		        is(not(EmbeddedBrowser.BrowserType.FIREFOX)));
-	}
 
 	@Before
 	public void before() throws URISyntaxException {


### PR DESCRIPTION
Remove the condition that skipped tests that use file scheme when executed with Firefox, the Firefox issue was already fixed (versions >=56, Travis CI using 60).