### PR TITLE
Remove obsolete Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: java
-sudo: false
 
 before_install:
   - mkdir geckodriver


### PR DESCRIPTION
Remove the `sudo: false` configuration, the builds run now always in the
same (new) infrastructure regardless of the configuration.