### PR TITLE
Enable all lint compile warnings

### DIFF
--- a/core/src/main/java/com/crawljax/core/plugin/Plugins.java
+++ b/core/src/main/java/com/crawljax/core/plugin/Plugins.java
@@ -42,7 +42,7 @@ public class Plugins {
 	private static final Logger LOGGER = LoggerFactory.getLogger(Plugins.class
 	        .getName());
 
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({ "unchecked", "deprecation" })
 	static final ImmutableSet<Class<? extends Plugin>> KNOWN_PLUGINS = ImmutableSet
 	        .of(DomChangeNotifierPlugin.class, OnBrowserCreatedPlugin.class,
 	                OnFireEventFailedPlugin.class,
@@ -58,6 +58,7 @@ public class Plugins {
 	private final MetricRegistry registry;
 
 	@Inject
+	@SuppressWarnings("deprecation")
 	public Plugins(CrawljaxConfiguration config, MetricRegistry registry) {
 		this.registry = registry;
 		List<? extends Plugin> plugins = config.getPlugins();
@@ -368,6 +369,7 @@ public class Plugins {
 	/**
 	 * Load and run the DomChangeNotifierPlugin.
 	 */
+	@SuppressWarnings("deprecation")
 	public boolean runDomChangeNotifierPlugins(final CrawlerContext context,
 	        final StateVertex stateBefore, final Eventable event,
 	        final StateVertex stateAfter) {

--- a/core/src/test/java/com/crawljax/core/plugin/PluginsTest.java
+++ b/core/src/test/java/com/crawljax/core/plugin/PluginsTest.java
@@ -39,6 +39,7 @@ public class PluginsTest {
 	private Plugins plugins;
 
 	@Mock
+	@SuppressWarnings("deprecation")
 	private DomChangeNotifierPlugin domChange;
 
 	@Mock
@@ -142,6 +143,7 @@ public class PluginsTest {
 	}
 
 	@Test
+	@SuppressWarnings("deprecation")
 	public void domChangeNotifierIsCalled() {
 		StateVertex stateBefore = mock(StateVertex.class);
 		Eventable eventable = mock(Eventable.class);
@@ -191,6 +193,7 @@ public class PluginsTest {
 	}
 
 	@Test
+	@SuppressWarnings("deprecation")
 	public void whenDomChangeErrorsTheDefaultIsUsed() {
 		StateVertex stateBefore = mock(StateVertex.class);
 		Eventable eventable = mock(Eventable.class);

--- a/core/src/test/java/com/crawljax/core/plugin/PluginsWithCrawlerTest.java
+++ b/core/src/test/java/com/crawljax/core/plugin/PluginsWithCrawlerTest.java
@@ -56,6 +56,7 @@ public class PluginsWithCrawlerTest {
 	private static CrawlSession session;
 
 	@BeforeClass
+	@SuppressWarnings("deprecation")
 	public static void setup() {
 		CrawljaxConfigurationBuilder builder = SERVER.newConfigBuilder("/crawler/");
 
@@ -204,6 +205,7 @@ public class PluginsWithCrawlerTest {
 	}
 
 	@Test
+	@SuppressWarnings("deprecation")
 	public void verifyOnUrlLoadFollowers() {
 		afterFirstPluginsIsFollowedBy(OnUrlLoadPlugin.class, ImmutableSet.of(
 		        OnInvariantViolationPlugin.class, OnNewStatePlugin.class,
@@ -251,6 +253,7 @@ public class PluginsWithCrawlerTest {
 	}
 
 	@Test
+	@SuppressWarnings("deprecation")
 	public void verifyPreStateCrawlingFollowers() {
 		pluginsIsFollowedBy(PreStateCrawlingPlugin.class,
 		        ImmutableSet.of(DomChangeNotifierPlugin.class, OnFireEventFailedPlugin.class,
@@ -259,6 +262,7 @@ public class PluginsWithCrawlerTest {
 	}
 
 	@Test
+	@SuppressWarnings("deprecation")
 	public void onRevisitStatesFollowers() {
 		pluginsIsFollowedBy(OnRevisitStatePlugin.class, ImmutableSet.of(
 		        OnFireEventFailedPlugin.class, DomChangeNotifierPlugin.class,
@@ -266,6 +270,7 @@ public class PluginsWithCrawlerTest {
 	}
 
 	@Test
+	@SuppressWarnings("deprecation")
 	public void verifyOnDomChangedFollowers() {
 		pluginsIsFollowedBy(DomChangeNotifierPlugin.class, ImmutableSet.of(
 		        OnFireEventFailedPlugin.class, DomChangeNotifierPlugin.class,
@@ -281,6 +286,7 @@ public class PluginsWithCrawlerTest {
 	}
 
 	@Test
+	@SuppressWarnings("deprecation")
 	public void domStatesChangesAreEqualToNumberOfStatesAfterIndex() {
 		int numberOfStates = session.getStateFlowGraph().getAllStates().size();
 		int newStatesAfterIndexPage = numberOfStates - 1;

--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,13 @@
 					<artifactId>maven-compiler-plugin</artifactId>
 					<groupId>org.apache.maven.plugins</groupId>
 					<version>3.7.0</version>
+					<configuration>
+						<fork>true</fork>
+						<compilerArgs>
+							<arg>-Xlint:all</arg>
+							<arg>-Werror</arg>
+						</compilerArgs>
+					</configuration>
 				</plugin>
 				<plugin>
 					<artifactId>maven-surefire-plugin</artifactId>


### PR DESCRIPTION
Compile with `-Xlint:all` and `-Werror`, to avoid/prevent warnings in
the code.
Suppress deprecation warnings in the usage of (legacy) Crawljax plugin.